### PR TITLE
chore: Enable no-db mode in beads config for container compatibility

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -10,8 +10,10 @@
 
 # Use no-db mode: load from JSONL, no SQLite, write back after each command
 # When true, bd will use .beads/issues.jsonl as the source of truth
-# instead of SQLite database
-# no-db: false
+# instead of SQLite database.
+# Enabled for this project to support containerized environments (Claude Code web,
+# Codespaces, etc.) where 9p/NFS filesystems don't support SQLite WAL locking.
+no-db: true
 
 # Disable daemon for RPC communication (forces direct database access)
 # no-daemon: false


### PR DESCRIPTION
## Summary

Enables JSONL-only (`no-db: true`) mode in beads config to support containerized environments.

## Changes

- `.beads/config.yaml`: Set `no-db: true` with explanatory comment

## Why This Matters

Containerized environments like Claude Code web and GitHub Codespaces use virtualized filesystems (9p, NFS) that don't support SQLite WAL mode locking. This causes `sqlite3: locking protocol` errors.

Setting `no-db: true` makes beads use JSONL directly as the source of truth, bypassing SQLite entirely. This is fully functional for all workflows.

## Manual Validation

- [x] `bd status` works without SQLite errors
- [x] `bd ready` shows issues correctly (61 issues, 22 ready)
- [x] Pre-commit hook handles no-db mode properly

## References

- [Previous PR with documentation updates](https://github.com/jlevy/markform/pull/2)
- [beads FAQ on no-db mode](https://github.com/steveyegge/beads/blob/main/docs/FAQ.md)