### PR TITLE
chore: release markform v0.1.2

### DIFF
--- a/.changeset/v0.1.2.md
+++ b/.changeset/v0.1.2.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Major internal refactoring and new features including: unified response model with notes and skip/abort reasons (%SKIP%/%ABORT% syntax), date-field and year-field types, research API and CLI command, smart fence serialization, forms directory for centralized output, report command with multi-format export, web search support for Anthropic/xAI, token counting in logs, interactive file viewer after fill, Prettier/ESLint integration, modularized parser, and comprehensive movie research examples

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.2
+
+### Patch Changes
+
+- 1ad64ba: Major internal refactoring and new features including: unified response model with notes and skip/abort reasons (%SKIP%/%ABORT% syntax), date-field and year-field types, research API and CLI command, smart fence serialization, forms directory for centralized output, report command with multi-format export, web search support for Anthropic/xAI, token counting in logs, interactive file viewer after fill, Prettier/ESLint integration, modularized parser, and comprehensive movie research examples
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary

Release v0.1.2 with 151 commits since v0.1.1, including major internal refactoring and new features:

- **Unified response model** with notes and skip/abort reasons (`%SKIP%`/`%ABORT%` syntax)
- **New field types**: `date-field` and `year-field`
- **Research API and CLI command** for automated research workflows
- **Smart fence serialization** for improved code block handling
- **Forms directory feature** for centralized form output
- **Report command** with multi-format export support
- **Web search support** for Anthropic/xAI providers
- **Token counting** in turn logging output
- **Interactive file viewer** after form fill
- **Prettier/ESLint integration** for code formatting
- **Modularized parser** for better maintainability
- **Comprehensive movie research examples**

## Release Checklist

After merging:
1. Pull main: `git checkout main && git pull`
2. Create tag: `git tag v0.1.2`
3. Push tag: `git push origin v0.1.2`

The tag push will trigger the release workflow to publish to npm.