### PR TITLE
Implement beads for examples and placeholders

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -234,6 +234,32 @@ Example: `pattern="^[A-Z]{1,5}$"` for a ticker symbol.
 
 The `role` attribute enables multi-actor workflows where different fields are assigned
 to different actors.
+
+**Text-entry field attributes (string, number, string-list, url, url-list only):**
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `placeholder` | string | Hint text shown in empty fields (displayed in UI) |
+| `examples` | string[] | Example values for the field (helps LLMs, shown in prompts) |
+
+These attributes are only valid on text-entry field types. Using them on chooser fields
+(single-select, multi-select, checkboxes) will result in a parse error.
+
+**Example with placeholder and examples:**
+```md
+{% string-field id="company_name" label="Company name" placeholder="Enter company name" examples=["ACME Corp", "Globex Inc"] %}{% /string-field %}
+```
+
+For number fields, examples must be valid numbers:
+```md
+{% number-field id="revenue" label="Revenue (USD)" placeholder="1000000" examples=["500000", "1000000", "5000000"] %}{% /number-field %}
+```
+
+For URL fields, examples must be valid URLs:
+```md
+{% url-field id="website" label="Website" placeholder="https://example.com" examples=["https://example.com", "https://github.com"] %}{% /url-field %}
+```
+
 When running the fill harness with `targetRoles`, only fields matching those roles are
 considered for completion.
 See **Role-filtered completion** in the ProgressState Definitions section.

--- a/packages/markform/DOCS.md
+++ b/packages/markform/DOCS.md
@@ -240,6 +240,20 @@ All fields support these attributes:
 | `role` | string | - | Target actor (`user`, `agent`) |
 | `priority` | string | medium | `high`, `medium`, `low` |
 
+**Text-entry fields only** (string, number, string-list, url, url-list):
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `placeholder` | string | Hint text shown in empty fields |
+| `examples` | string[] | Example values (helps LLMs understand expected format) |
+
+```markdown
+{% string-field id="name" label="Name" placeholder="Enter your name" examples=["John Doe", "Jane Smith"] %}{% /string-field %}
+{% number-field id="revenue" label="Revenue" placeholder="1000000" examples=["500000", "1000000"] %}{% /number-field %}
+```
+
+Note: `placeholder` and `examples` are NOT valid on chooser fields (single-select, multi-select, checkboxes).
+
 ## Documentation Blocks
 
 Add context to fields, groups, or the form.

--- a/packages/markform/examples/simple/simple-mock-filled.form.md
+++ b/packages/markform/examples/simple/simple-mock-filled.form.md
@@ -18,7 +18,7 @@ Fill all fields using interactive prompts - no LLM API key needed.
 
 {% field-group id="basic_fields" title="Basic Fields" %}
 
-{% string-field id="name" label="Name" role="user" required=true minLength=2 maxLength=50 %}
+{% string-field id="name" label="Name" role="user" required=true minLength=2 maxLength=50 placeholder="Enter your name" examples=["John Smith", "Jane Doe"] %}
 ```value
 Alice Johnson
 ```
@@ -28,19 +28,19 @@ Alice Johnson
 Enter your full name (2-50 characters).
 {% /instructions %}
 
-{% string-field id="email" label="Email" role="user" required=true pattern="^[^@]+@[^@]+\\.[^@]+$" %}
+{% string-field id="email" label="Email" role="user" required=true pattern="^[^@]+@[^@]+\\.[^@]+$" placeholder="email@example.com" examples=["alice@company.com", "bob@example.org"] %}
 ```value
 alice@example.com
 ```
 {% /string-field %}
 
-{% number-field id="age" label="Age" role="user" required=true min=0 max=150 integer=true %}
+{% number-field id="age" label="Age" role="user" required=true min=0 max=150 integer=true placeholder="25" examples=["18", "30", "45"] %}
 ```value
 32
 ```
 {% /number-field %}
 
-{% number-field id="score" label="Score" role="user" min=0.0 max=100.0 %}
+{% number-field id="score" label="Score" role="user" min=0.0 max=100.0 placeholder="85.5" examples=["75.0", "90.5", "100.0"] %}
 ```value
 87.5
 ```
@@ -116,7 +116,7 @@ Answer yes or no for each confirmation. All must be explicitly answered.
 
 {% field-group id="url_fields" title="URL Fields" %}
 
-{% url-field id="website" label="Website" role="user" required=true %}
+{% url-field id="website" label="Website" role="user" required=true placeholder="https://example.com" examples=["https://github.com/user/repo", "https://company.com"] %}
 ```value
 https://alice.dev
 ```
@@ -126,7 +126,7 @@ https://alice.dev
 Enter your website URL (must be http or https).
 {% /instructions %}
 
-{% url-list id="references" label="References" role="user" minItems=1 maxItems=5 uniqueItems=true %}
+{% url-list id="references" label="References" role="user" minItems=1 maxItems=5 uniqueItems=true placeholder="https://docs.example.com" examples=["https://wikipedia.org/wiki/Example", "https://docs.github.com/en"] %}
 ```value
 https://docs.example.com/guide
 https://github.com/example/project

--- a/packages/markform/examples/simple/simple-skipped-filled.form.md
+++ b/packages/markform/examples/simple/simple-skipped-filled.form.md
@@ -18,7 +18,7 @@ Fill all fields using interactive prompts - no LLM API key needed.
 
 {% field-group id="basic_fields" title="Basic Fields" %}
 
-{% string-field id="name" label="Name" maxLength=50 minLength=2 required=true role="user" %}
+{% string-field id="name" label="Name" maxLength=50 minLength=2 required=true role="user" placeholder="Enter your name" examples=["John Smith", "Jane Doe"] %}
 ```value
 Test User
 ```
@@ -28,19 +28,19 @@ Test User
 Enter your full name (2-50 characters).
 {% /instructions %}
 
-{% string-field id="email" label="Email" pattern="^[^@]+@[^@]+\\.[^@]+$" required=true role="user" %}
+{% string-field id="email" label="Email" pattern="^[^@]+@[^@]+\\.[^@]+$" required=true role="user" placeholder="email@example.com" examples=["alice@company.com", "bob@example.org"] %}
 ```value
 test@example.com
 ```
 {% /string-field %}
 
-{% number-field id="age" integer=true label="Age" max=150 min=0 required=true role="user" %}
+{% number-field id="age" integer=true label="Age" max=150 min=0 required=true role="user" placeholder="25" examples=["18", "30", "45"] %}
 ```value
 25
 ```
 {% /number-field %}
 
-{% number-field id="score" label="Score" max=100 min=0 role="user" state="skipped" %}
+{% number-field id="score" label="Score" max=100 min=0 role="user" state="skipped" placeholder="85.5" examples=["75.0", "90.5", "100.0"] %}
 ```value
 %SKIP% (Not needed for this test)
 ```
@@ -115,7 +115,7 @@ Answer yes or no for each confirmation. All must be explicitly answered.
 
 {% field-group id="url_fields" title="URL Fields" %}
 
-{% url-field id="website" label="Website" required=true role="user" %}
+{% url-field id="website" label="Website" required=true role="user" placeholder="https://example.com" examples=["https://github.com/user/repo", "https://company.com"] %}
 ```value
 https://test.example.com
 ```
@@ -125,7 +125,7 @@ https://test.example.com
 Enter your website URL (must be http or https).
 {% /instructions %}
 
-{% url-list id="references" label="References" maxItems=5 minItems=1 role="user" uniqueItems=true %}
+{% url-list id="references" label="References" maxItems=5 minItems=1 role="user" uniqueItems=true placeholder="https://docs.example.com" examples=["https://wikipedia.org/wiki/Example", "https://docs.github.com/en"] %}
 ```value
 https://docs.example.com
 ```

--- a/packages/markform/examples/simple/simple-with-skips.session.yaml
+++ b/packages/markform/examples/simple/simple-with-skips.session.yaml
@@ -121,7 +121,7 @@ turns:
           value: https://test.example.com
     after:
       required_issue_count: 0
-      markdown_sha256: 62c9aad095c2ea5c2947c308c5e4b3c4cbc677a7e481971871c5091d5ca27b02
+      markdown_sha256: 3a9ecee6dbd7e576c15956149b2594c8ee9fba949ba5ec58bc75550ce2db267c
       answered_field_count: 10
       skipped_field_count: 0
   - turn: 2
@@ -181,7 +181,7 @@ turns:
           reason: No value in mock form
     after:
       required_issue_count: 0
-      markdown_sha256: 5ca306e53bdb0213b0558f6132c7a5af491c40c8765f25bc7047efa0478b7876
+      markdown_sha256: 457baf8e026da37dcbf116c97519db6de147a59df774c63f21b4984835cf286f
       answered_field_count: 11
       skipped_field_count: 4
 final:

--- a/packages/markform/examples/simple/simple.form.md
+++ b/packages/markform/examples/simple/simple.form.md
@@ -18,17 +18,17 @@ Fill all fields using interactive prompts - no LLM API key needed.
 
 {% field-group id="basic_fields" title="Basic Fields" %}
 
-{% string-field id="name" label="Name" role="user" required=true minLength=2 maxLength=50 %}{% /string-field %}
+{% string-field id="name" label="Name" role="user" required=true minLength=2 maxLength=50 placeholder="Enter your name" examples=["John Smith", "Jane Doe"] %}{% /string-field %}
 
 {% instructions ref="name" %}
 Enter your full name (2-50 characters).
 {% /instructions %}
 
-{% string-field id="email" label="Email" role="user" required=true pattern="^[^@]+@[^@]+\\.[^@]+$" %}{% /string-field %}
+{% string-field id="email" label="Email" role="user" required=true pattern="^[^@]+@[^@]+\\.[^@]+$" placeholder="email@example.com" examples=["alice@company.com", "bob@example.org"] %}{% /string-field %}
 
-{% number-field id="age" label="Age" role="user" required=true min=0 max=150 integer=true %}{% /number-field %}
+{% number-field id="age" label="Age" role="user" required=true min=0 max=150 integer=true placeholder="25" examples=["18", "30", "45"] %}{% /number-field %}
 
-{% number-field id="score" label="Score" role="user" min=0.0 max=100.0 %}{% /number-field %}
+{% number-field id="score" label="Score" role="user" min=0.0 max=100.0 placeholder="85.5" examples=["75.0", "90.5", "100.0"] %}{% /number-field %}
 
 {% instructions ref="score" %}
 Enter a score between 0 and 100 (optional).
@@ -94,13 +94,13 @@ Answer yes or no for each confirmation. All must be explicitly answered.
 
 {% field-group id="url_fields" title="URL Fields" %}
 
-{% url-field id="website" label="Website" role="user" required=true %}{% /url-field %}
+{% url-field id="website" label="Website" role="user" required=true placeholder="https://example.com" examples=["https://github.com/user/repo", "https://company.com"] %}{% /url-field %}
 
 {% instructions ref="website" %}
 Enter your website URL (must be http or https).
 {% /instructions %}
 
-{% url-list id="references" label="References" role="user" minItems=1 maxItems=5 uniqueItems=true %}{% /url-list %}
+{% url-list id="references" label="References" role="user" minItems=1 maxItems=5 uniqueItems=true placeholder="https://docs.example.com" examples=["https://wikipedia.org/wiki/Example", "https://docs.github.com/en"] %}{% /url-list %}
 
 {% instructions ref="references" %}
 Add 1-5 unique reference URLs for sources or documentation.

--- a/packages/markform/examples/simple/simple.session.yaml
+++ b/packages/markform/examples/simple/simple.session.yaml
@@ -122,7 +122,7 @@ turns:
           value: https://alice.dev
     after:
       required_issue_count: 0
-      markdown_sha256: 82ebecc97db1321838d47491c23ab951525e1fa5fd14590cd306565faa00b05f
+      markdown_sha256: 2043ec76d913d290881480d5d2ca4de9ef6a3fdbdb626c65f6c33943be8524db
       answered_field_count: 10
       skipped_field_count: 0
   - turn: 2
@@ -181,7 +181,7 @@ turns:
           value: 87.5
     after:
       required_issue_count: 0
-      markdown_sha256: 09ad2c0b12f3b27505ea3fbcfd35e025e94d906c1cb9701322b793b233db54dd
+      markdown_sha256: bdf33a4ca1ca4b0ae0005a5ff53b70a19b58838ac1076fe42a91de0781986096
       answered_field_count: 14
       skipped_field_count: 1
 final:

--- a/packages/markform/src/cli/commands/export.ts
+++ b/packages/markform/src/cli/commands/export.ts
@@ -24,6 +24,8 @@ interface ExportField {
   label: string;
   required: boolean;
   options?: { id: string; label: string }[];
+  placeholder?: string;
+  examples?: string[];
 }
 
 interface ExportGroup {
@@ -117,6 +119,8 @@ export function registerExportCommand(program: Command): void {
                     })),
                   }
                 : {}),
+              ...(field.placeholder ? { placeholder: field.placeholder } : {}),
+              ...(field.examples && field.examples.length > 0 ? { examples: field.examples } : {}),
             })),
           })),
         };

--- a/packages/markform/src/cli/commands/serve.ts
+++ b/packages/markform/src/cli/commands/serve.ts
@@ -781,8 +781,11 @@ function renderStringInput(
   const requiredAttr = field.required ? ' required' : '';
   const minLengthAttr = field.minLength !== undefined ? ` minlength="${field.minLength}"` : '';
   const maxLengthAttr = field.maxLength !== undefined ? ` maxlength="${field.maxLength}"` : '';
+  const placeholderAttr = field.placeholder
+    ? ` placeholder="${escapeHtml(field.placeholder)}"`
+    : '';
 
-  return `<input type="text" id="field-${field.id}" name="${field.id}" value="${escapeHtml(currentValue)}"${requiredAttr}${minLengthAttr}${maxLengthAttr}${disabledAttr}>`;
+  return `<input type="text" id="field-${field.id}" name="${field.id}" value="${escapeHtml(currentValue)}"${requiredAttr}${minLengthAttr}${maxLengthAttr}${placeholderAttr}${disabledAttr}>`;
 }
 
 /**
@@ -798,8 +801,11 @@ function renderNumberInput(
   const minAttr = field.min !== undefined ? ` min="${field.min}"` : '';
   const maxAttr = field.max !== undefined ? ` max="${field.max}"` : '';
   const stepAttr = field.integer ? ' step="1"' : '';
+  const placeholderAttr = field.placeholder
+    ? ` placeholder="${escapeHtml(field.placeholder)}"`
+    : '';
 
-  return `<input type="number" id="field-${field.id}" name="${field.id}" value="${escapeHtml(currentValue)}"${requiredAttr}${minAttr}${maxAttr}${stepAttr}${disabledAttr}>`;
+  return `<input type="number" id="field-${field.id}" name="${field.id}" value="${escapeHtml(currentValue)}"${requiredAttr}${minAttr}${maxAttr}${stepAttr}${placeholderAttr}${disabledAttr}>`;
 }
 
 /**
@@ -813,8 +819,12 @@ function renderStringListInput(
   const items = value?.kind === 'string_list' ? value.items : [];
   const currentValue = items.join('\n');
   const requiredAttr = field.required ? ' required' : '';
+  // Use field placeholder or default
+  const placeholderText = field.placeholder
+    ? `${escapeHtml(field.placeholder)} (one item per line)`
+    : 'Enter one item per line';
 
-  return `<textarea id="field-${field.id}" name="${field.id}" placeholder="Enter one item per line"${requiredAttr}${disabledAttr}>${escapeHtml(currentValue)}</textarea>`;
+  return `<textarea id="field-${field.id}" name="${field.id}" placeholder="${placeholderText}"${requiredAttr}${disabledAttr}>${escapeHtml(currentValue)}</textarea>`;
 }
 
 /**
@@ -827,8 +837,10 @@ function renderUrlInput(
 ): string {
   const currentValue = value?.kind === 'url' && value.value !== null ? value.value : '';
   const requiredAttr = field.required ? ' required' : '';
+  // Use field placeholder or default
+  const placeholderText = field.placeholder ?? 'https://example.com';
 
-  return `<input type="url" id="field-${field.id}" name="${field.id}" value="${escapeHtml(currentValue)}" placeholder="https://example.com"${requiredAttr}${disabledAttr}>`;
+  return `<input type="url" id="field-${field.id}" name="${field.id}" value="${escapeHtml(currentValue)}" placeholder="${escapeHtml(placeholderText)}"${requiredAttr}${disabledAttr}>`;
 }
 
 /**
@@ -842,8 +854,12 @@ function renderUrlListInput(
   const items = value?.kind === 'url_list' ? value.items : [];
   const currentValue = items.join('\n');
   const requiredAttr = field.required ? ' required' : '';
+  // Use field placeholder or default
+  const placeholderText = field.placeholder
+    ? `${escapeHtml(field.placeholder)} (one URL per line)`
+    : 'Enter one URL per line';
 
-  return `<textarea id="field-${field.id}" name="${field.id}" placeholder="Enter one URL per line"${requiredAttr}${disabledAttr}>${escapeHtml(currentValue)}</textarea>`;
+  return `<textarea id="field-${field.id}" name="${field.id}" placeholder="${placeholderText}"${requiredAttr}${disabledAttr}>${escapeHtml(currentValue)}</textarea>`;
 }
 
 /**

--- a/packages/markform/src/cli/lib/interactivePrompts.ts
+++ b/packages/markform/src/cli/lib/interactivePrompts.ts
@@ -119,9 +119,13 @@ async function promptForString(ctx: FieldPromptContext): Promise<Patch | null> {
   const field = ctx.field as StringField;
   const currentVal = ctx.currentValue?.kind === 'string' ? ctx.currentValue.value : null;
 
+  // Prefer field placeholder, fall back to current value or description
+  const placeholderText =
+    field.placeholder ?? currentVal ?? (ctx.description ? ctx.description.slice(0, 60) : undefined);
+
   const result = await p.text({
     message: formatFieldLabel(ctx),
-    placeholder: currentVal ?? (ctx.description ? ctx.description.slice(0, 60) : undefined),
+    placeholder: placeholderText,
     initialValue: currentVal ?? '',
     validate: (value) => {
       if (field.required && !value.trim()) {
@@ -163,9 +167,13 @@ async function promptForNumber(ctx: FieldPromptContext): Promise<Patch | null> {
   const field = ctx.field as NumberField;
   const currentVal = ctx.currentValue?.kind === 'number' ? ctx.currentValue.value : null;
 
+  // Prefer field placeholder, fall back to current value
+  const placeholderText =
+    field.placeholder ?? (currentVal !== null ? String(currentVal) : undefined);
+
   const result = await p.text({
     message: formatFieldLabel(ctx),
-    placeholder: currentVal !== null ? String(currentVal) : undefined,
+    placeholder: placeholderText,
     initialValue: currentVal !== null ? String(currentVal) : '',
     validate: (value) => {
       if (field.required && !value.trim()) {
@@ -214,9 +222,15 @@ async function promptForStringList(ctx: FieldPromptContext): Promise<Patch | nul
   const field = ctx.field as StringListField;
   const currentItems = ctx.currentValue?.kind === 'string_list' ? ctx.currentValue.items : [];
 
-  const hint = ctx.description
-    ? `${ctx.description.slice(0, 50)}... (one item per line)`
-    : 'Enter items, one per line. Press Enter twice when done.';
+  // Prefer field placeholder, fall back to description or default hint
+  let hint: string;
+  if (field.placeholder) {
+    hint = `${field.placeholder} (one item per line)`;
+  } else if (ctx.description) {
+    hint = `${ctx.description.slice(0, 50)}... (one item per line)`;
+  } else {
+    hint = 'Enter items, one per line. Press Enter twice when done.';
+  }
 
   const result = await p.text({
     message: formatFieldLabel(ctx),
@@ -443,9 +457,12 @@ async function promptForUrl(ctx: FieldPromptContext): Promise<Patch | null> {
   const field = ctx.field as UrlField;
   const currentVal = ctx.currentValue?.kind === 'url' ? ctx.currentValue.value : null;
 
+  // Prefer field placeholder, fall back to current value or default
+  const placeholderText = field.placeholder ?? currentVal ?? 'https://example.com';
+
   const result = await p.text({
     message: formatFieldLabel(ctx),
-    placeholder: currentVal ?? 'https://example.com',
+    placeholder: placeholderText,
     initialValue: currentVal ?? '',
     validate: (value) => {
       if (field.required && !value.trim()) {
@@ -487,9 +504,15 @@ async function promptForUrlList(ctx: FieldPromptContext): Promise<Patch | null> 
   const field = ctx.field as UrlListField;
   const currentItems = ctx.currentValue?.kind === 'url_list' ? ctx.currentValue.items : [];
 
-  const hint = ctx.description
-    ? `${ctx.description.slice(0, 50)}... (one URL per line)`
-    : 'Enter URLs, one per line. Press Enter twice when done.';
+  // Prefer field placeholder, fall back to description or default hint
+  let hint: string;
+  if (field.placeholder) {
+    hint = `${field.placeholder} (one URL per line)`;
+  } else if (ctx.description) {
+    hint = `${ctx.description.slice(0, 50)}... (one URL per line)`;
+  } else {
+    hint = 'Enter URLs, one per line. Press Enter twice when done.';
+  }
 
   const result = await p.text({
     message: formatFieldLabel(ctx),

--- a/packages/markform/src/engine/coreTypes.ts
+++ b/packages/markform/src/engine/coreTypes.ts
@@ -128,6 +128,33 @@ export interface FieldBase {
   validate?: ValidatorRef[];
   /** Whether to include this field in report output. Default: true */
   report?: boolean;
+  /** Hint text for empty field (text-entry fields only) */
+  placeholder?: string;
+  /** Example values (text-entry fields only) */
+  examples?: string[];
+}
+
+// =============================================================================
+// Field Kind Categories
+// =============================================================================
+
+/** Field kinds that accept text entry (support placeholder/examples) */
+export const TEXT_ENTRY_FIELD_KINDS = [
+  'string',
+  'number',
+  'string_list',
+  'url',
+  'url_list',
+] as const;
+
+/** Field kinds that are choosers (do NOT support placeholder/examples) */
+export const CHOOSER_FIELD_KINDS = ['single_select', 'multi_select', 'checkboxes'] as const;
+
+/**
+ * Check if a field kind accepts text entry (supports placeholder/examples).
+ */
+export function isTextEntryFieldKind(kind: FieldKind): boolean {
+  return (TEXT_ENTRY_FIELD_KINDS as readonly string[]).includes(kind);
 }
 
 /** String field - single or multiline text */
@@ -898,6 +925,9 @@ const FieldBaseSchemaPartial = {
   priority: FieldPriorityLevelSchema,
   role: z.string(),
   validate: z.array(ValidatorRefSchema).optional(),
+  report: z.boolean().optional(),
+  placeholder: z.string().optional(),
+  examples: z.array(z.string()).optional(),
 };
 
 // Field schemas

--- a/packages/markform/src/engine/parseHelpers.ts
+++ b/packages/markform/src/engine/parseHelpers.ts
@@ -133,6 +133,26 @@ export function getValidateAttr(node: Node): ValidatorRef[] | undefined {
 }
 
 /**
+ * Get string array attribute value or undefined.
+ * Handles both single string (converts to array) and array formats.
+ */
+export function getStringArrayAttr(node: Node, name: string): string[] | undefined {
+  const value: unknown = node.attributes?.[name];
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    // Filter to only strings
+    const strings = value.filter((v): v is string => typeof v === 'string');
+    return strings.length > 0 ? strings : undefined;
+  }
+  if (typeof value === 'string') {
+    return [value];
+  }
+  return undefined;
+}
+
+/**
  * Parsed option item from AST.
  */
 export interface ParsedOptionItem {

--- a/packages/markform/src/engine/serialize.ts
+++ b/packages/markform/src/engine/serialize.ts
@@ -270,6 +270,12 @@ function serializeStringField(field: StringField, response: FieldResponse | unde
   if (field.report !== undefined) {
     attrs.report = field.report;
   }
+  if (field.placeholder) {
+    attrs.placeholder = field.placeholder;
+  }
+  if (field.examples && field.examples.length > 0) {
+    attrs.examples = field.examples;
+  }
 
   // Add state attribute for skipped/aborted (markform-216)
   if (response?.state === 'skipped' || response?.state === 'aborted') {
@@ -324,6 +330,12 @@ function serializeNumberField(field: NumberField, response: FieldResponse | unde
   }
   if (field.report !== undefined) {
     attrs.report = field.report;
+  }
+  if (field.placeholder) {
+    attrs.placeholder = field.placeholder;
+  }
+  if (field.examples && field.examples.length > 0) {
+    attrs.examples = field.examples;
   }
 
   // Add state attribute for skipped/aborted (markform-216)
@@ -388,6 +400,12 @@ function serializeStringListField(
   }
   if (field.report !== undefined) {
     attrs.report = field.report;
+  }
+  if (field.placeholder) {
+    attrs.placeholder = field.placeholder;
+  }
+  if (field.examples && field.examples.length > 0) {
+    attrs.examples = field.examples;
   }
 
   // Add state attribute for skipped/aborted (markform-216)
@@ -601,6 +619,12 @@ function serializeUrlField(field: UrlField, response: FieldResponse | undefined)
   if (field.report !== undefined) {
     attrs.report = field.report;
   }
+  if (field.placeholder) {
+    attrs.placeholder = field.placeholder;
+  }
+  if (field.examples && field.examples.length > 0) {
+    attrs.examples = field.examples;
+  }
 
   // Add state attribute for skipped/aborted (markform-216)
   if (response?.state === 'skipped' || response?.state === 'aborted') {
@@ -655,6 +679,12 @@ function serializeUrlListField(field: UrlListField, response: FieldResponse | un
   }
   if (field.report !== undefined) {
     attrs.report = field.report;
+  }
+  if (field.placeholder) {
+    attrs.placeholder = field.placeholder;
+  }
+  if (field.examples && field.examples.length > 0) {
+    attrs.examples = field.examples;
   }
 
   // Add state attribute for skipped/aborted (markform-216)

--- a/packages/markform/tests/unit/engine/parse.test.ts
+++ b/packages/markform/tests/unit/engine/parse.test.ts
@@ -1345,4 +1345,269 @@ Note text.
       expect(() => parseForm(markdown)).toThrow(/missing.*role/i);
     });
   });
+
+  describe('placeholder and examples attributes (markform-345)', () => {
+    it('parses placeholder on string field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% string-field id="name" label="Name" placeholder="Enter your name" %}{% /string-field %}
+{% /field-group %}
+
+{% /form %}
+`;
+      const result = parseForm(markdown);
+      const field = result.schema.groups[0]?.children[0];
+
+      expect(field?.placeholder).toBe('Enter your name');
+    });
+
+    it('parses examples as single string on string field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% string-field id="name" label="Name" examples="John Doe" %}{% /string-field %}
+{% /field-group %}
+
+{% /form %}
+`;
+      const result = parseForm(markdown);
+      const field = result.schema.groups[0]?.children[0];
+
+      expect(field?.examples).toEqual(['John Doe']);
+    });
+
+    it('parses examples as array on string field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% string-field id="name" label="Name" examples=["John Doe", "Jane Smith", "Alice Johnson"] %}{% /string-field %}
+{% /field-group %}
+
+{% /form %}
+`;
+      const result = parseForm(markdown);
+      const field = result.schema.groups[0]?.children[0];
+
+      expect(field?.examples).toEqual(['John Doe', 'Jane Smith', 'Alice Johnson']);
+    });
+
+    it('parses placeholder and examples on number field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% number-field id="age" label="Age" placeholder="25" examples=["18", "25", "65"] %}{% /number-field %}
+{% /field-group %}
+
+{% /form %}
+`;
+      const result = parseForm(markdown);
+      const field = result.schema.groups[0]?.children[0];
+
+      expect(field?.placeholder).toBe('25');
+      expect(field?.examples).toEqual(['18', '25', '65']);
+    });
+
+    it('parses placeholder and examples on url field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% url-field id="website" label="Website" placeholder="https://example.com" examples=["https://example.com", "https://github.com"] %}{% /url-field %}
+{% /field-group %}
+
+{% /form %}
+`;
+      const result = parseForm(markdown);
+      const field = result.schema.groups[0]?.children[0];
+
+      expect(field?.placeholder).toBe('https://example.com');
+      expect(field?.examples).toEqual(['https://example.com', 'https://github.com']);
+    });
+
+    it('parses placeholder on string-list field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% string-list id="tags" label="Tags" placeholder="technology" examples=["tech", "science", "business"] %}{% /string-list %}
+{% /field-group %}
+
+{% /form %}
+`;
+      const result = parseForm(markdown);
+      const field = result.schema.groups[0]?.children[0];
+
+      expect(field?.placeholder).toBe('technology');
+      expect(field?.examples).toEqual(['tech', 'science', 'business']);
+    });
+
+    it('parses placeholder on url-list field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% url-list id="sources" label="Sources" placeholder="https://example.com" examples=["https://example.com/1", "https://example.com/2"] %}{% /url-list %}
+{% /field-group %}
+
+{% /form %}
+`;
+      const result = parseForm(markdown);
+      const field = result.schema.groups[0]?.children[0];
+
+      expect(field?.placeholder).toBe('https://example.com');
+      expect(field?.examples).toEqual(['https://example.com/1', 'https://example.com/2']);
+    });
+
+    it('throws error on placeholder for single-select field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% single-select id="priority" label="Priority" placeholder="Select one" %}
+- [ ] Low {% #low %}
+- [ ] High {% #high %}
+{% /single-select %}
+{% /field-group %}
+
+{% /form %}
+`;
+      expect(() => parseForm(markdown)).toThrow(ParseError);
+      expect(() => parseForm(markdown)).toThrow(/placeholder.*only valid on text-entry fields/i);
+    });
+
+    it('throws error on examples for multi-select field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% multi-select id="categories" label="Categories" examples=["cat1", "cat2"] %}
+- [ ] Option 1 {% #opt1 %}
+- [ ] Option 2 {% #opt2 %}
+{% /multi-select %}
+{% /field-group %}
+
+{% /form %}
+`;
+      expect(() => parseForm(markdown)).toThrow(ParseError);
+      expect(() => parseForm(markdown)).toThrow(/examples.*only valid on text-entry fields/i);
+    });
+
+    it('throws error on placeholder for checkboxes field', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% checkboxes id="tasks" label="Tasks" placeholder="Check all that apply" %}
+- [ ] Task 1 {% #t1 %}
+- [ ] Task 2 {% #t2 %}
+{% /checkboxes %}
+{% /field-group %}
+
+{% /form %}
+`;
+      expect(() => parseForm(markdown)).toThrow(ParseError);
+      expect(() => parseForm(markdown)).toThrow(/placeholder.*only valid on text-entry fields/i);
+    });
+
+    it('throws error on invalid number example', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% number-field id="age" label="Age" examples=["25", "not-a-number", "30"] %}{% /number-field %}
+{% /field-group %}
+
+{% /form %}
+`;
+      expect(() => parseForm(markdown)).toThrow(ParseError);
+      expect(() => parseForm(markdown)).toThrow(
+        /invalid example.*not-a-number.*must be a valid number/i,
+      );
+    });
+
+    it('throws error on invalid URL example', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% url-field id="website" label="Website" examples=["https://example.com", "not-a-url"] %}{% /url-field %}
+{% /field-group %}
+
+{% /form %}
+`;
+      expect(() => parseForm(markdown)).toThrow(ParseError);
+      expect(() => parseForm(markdown)).toThrow(/invalid example.*not-a-url.*must be a valid URL/i);
+    });
+
+    it('throws error on invalid URL example in url-list', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% field-group id="g1" %}
+{% url-list id="sources" label="Sources" examples=["not-a-url", "https://example.com"] %}{% /url-list %}
+{% /field-group %}
+
+{% /form %}
+`;
+      expect(() => parseForm(markdown)).toThrow(ParseError);
+      expect(() => parseForm(markdown)).toThrow(/invalid example.*not-a-url.*must be a valid URL/i);
+    });
+  });
 });


### PR DESCRIPTION
Implements markform-345 epic: Examples and Placeholder Field Attributes

Phase 1 - Core types and parser:
- Add placeholder (string) and examples (string[]) to FieldBase interface
- Add TEXT_ENTRY_FIELD_KINDS and CHOOSER_FIELD_KINDS constants
- Add isTextEntryFieldKind() helper function
- Extract placeholder/examples in text-entry field parsers (string, number, string-list, url, url-list)
- Validate placeholder/examples are NOT used on chooser fields (single-select, multi-select, checkboxes)
- Type-validate examples for number fields (must parse as numbers)
- Type-validate examples for URL fields (must be valid URLs)

Phase 2 - Serialization and export:
- Include placeholder/examples in serialized form output
- Add placeholder/examples to ExportField interface in export command
- Add 13 round-trip tests for placeholder/examples parsing

Phase 3 - UI integration:
- Console UI: Show placeholder in fill prompts for all text-entry fields
- Web UI: Add placeholder attribute to input elements for all text-entry fields

Phase 4 - Documentation:
- Update SPEC.md with text-entry field attributes documentation
- Update DOCS.md with placeholder/examples in Common Attributes section
- Update simple example form with placeholder/examples demonstrations
- Update golden test fixtures and session hashes