### PR TITLE
chore: release markform v0.1.3

### DIFF
--- a/.changeset/v0.1.3.md
+++ b/.changeset/v0.1.3.md
@@ -1,8 +1,0 @@
----
-"markform": patch
----
-
-- fix: Move ai from peerDependencies to regular dependencies (resolves install issues for new users)
-- refactor: Change multi-format export from raw to report format
-- docs: Update README example and add MPAA rating to minimal form
-- fix(examples): simplify movie-research-minimal form structure

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,14 @@
 # markform
 
+## 0.1.3
+
+### Patch Changes
+
+- 3ea571b: - fix: Move ai from peerDependencies to regular dependencies (resolves install issues for new users)
+  - refactor: Change multi-format export from raw to report format
+  - docs: Update README example and add MPAA rating to minimal form
+  - fix(examples): simplify movie-research-minimal form structure
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary
- Release v0.1.3 with patch changes

### Changes
- fix: Move ai from peerDependencies to regular dependencies (resolves install issues for new users)
- refactor: Change multi-format export from raw to report format
- docs: Update README example and add MPAA rating to minimal form
- fix(examples): simplify movie-research-minimal form structure

## Test plan
- [x] All 600 tests pass
- [x] Changelog updated
- [x] Version bumped to 0.1.3