### PR TITLE
chore: release markform v0.1.4

### DIFF
--- a/.changeset/v0.1.4.md
+++ b/.changeset/v0.1.4.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Add custom tool injection, unified field tag syntax, table-field type, date/year field support, and various bug fixes

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.4
+
+### Patch Changes
+
+- 5b1794b: Add custom tool injection, unified field tag syntax, table-field type, date/year field support, and various bug fixes
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary
- Release markform v0.1.4 with the following changes:
  - Add custom tool injection for LiveAgent and FillOptions
  - Unified field tag syntax
  - Table-field type for structured tabular data
  - Date and year field support
  - Various parser bug fixes and documentation updates

## Test plan
- [x] All 671 tests pass
- [x] Build succeeds
- [x] Lint passes