### PR TITLE
chore: release markform v0.1.6

### DIFF
--- a/.changeset/v0.1.6.md
+++ b/.changeset/v0.1.6.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Add FillCallbacks for harness observability, make core library Node.js-free

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.6
+
+### Patch Changes
+
+- 3862a96: Add FillCallbacks for harness observability, make core library Node.js-free
+
 ## 0.1.5
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary
- Release markform v0.1.6

## Patch Changes
- Add FillCallbacks for harness observability, make core library Node.js-free

### Highlights
- **FillCallbacks**: New callback interface for observing form fill progress (onTurnStart, onLlmCall, onToolCall)
- **Node.js-free core**: Core library can now run in non-Node.js environments
- **Web search spinner feedback**: CLI now shows spinner feedback for web search tool calls