### PR TITLE
chore: release markform v0.1.7

### DIFF
--- a/.changeset/v0.1.7.md
+++ b/.changeset/v0.1.7.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Unified fill logging, CLI improvements, JSON Schema enhancements, Zod v4 upgrade

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.7
+
+### Patch Changes
+
+- 71692eb: Unified fill logging, CLI improvements, JSON Schema enhancements, Zod v4 upgrade
+
 ## 0.1.6
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary
- Unified fill logging architecture
- CLI improvements (browse, run, examples, status)
- JSON Schema enhancements
- Zod v4 and Vitest v4 upgrades
- Dynamic git-based versioning

## Release Notes
See CHANGELOG.md for details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release: `markform` 0.1.7**
> 
> - Update `CHANGELOG.md` to note unified fill logging, CLI improvements, JSON Schema enhancements, and Zod v4 upgrade
> - Bump `package.json` version from `0.1.6` to `0.1.7`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f769db82d0e496d7c9dbe140be841ebb7eca2e1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->