### PR TITLE
chore: release markform v0.1.8

### DIFF
--- a/.changeset/v0.1.8.md
+++ b/.changeset/v0.1.8.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Fix serialization of table values and frontmatter, improve rejection feedback handling in LLM prompts, and add comprehensive golden test coverage

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.8
+
+### Patch Changes
+
+- b803791: Fix serialization of table values and frontmatter, improve rejection feedback handling in LLM prompts, and add comprehensive golden test coverage
+
 ## 0.1.7
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary

Release v0.1.8 with the following changes:
- Fix serialization of table values without fences and preserve frontmatter
- Improve rejection feedback handling in LLM prompts
- Add comprehensive golden test coverage for exports

## Changes since v0.1.7

- fix(serialize): table values without fences and preserve frontmatter
- fix(cli): add missing space in Markform tag colorization
- fix: Include full table content in report and YAML exports
- feat: Record rejected patches in session transcripts
- fix: Include correct patch format in rejection feedback
- fix: Add rejection feedback to LLM context prompts
- feat: Add prompt context logging to session transcripts
- fix: Add table field patch format to LLM prompts
- feat: Replace patchesRejected boolean with rejectedPatches array
- feat: Add comprehensive golden test coverage for exports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Release bump with documented patch changes.
> 
> - Update version in `packages/markform/package.json` from `0.1.7` to `0.1.8`
> - Update `packages/markform/CHANGELOG.md` with: fix table/frontmatter serialization, improved rejection feedback handling in LLM prompts, and added comprehensive golden test coverage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f266c9df98a3beb9deb4fe50f0f455f1ed67143. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->