### PR TITLE
chore: release markform v0.1.9

### DIFF
--- a/.changeset/v0.1.9.md
+++ b/.changeset/v0.1.9.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Improve serve command with syntax highlighting and tabs, add inline field instructions to prompts, rename generatePatches to fill_form, add wire format to session logs, fix table/date/year support in CLI, fix multi_select infinite loop

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.9
+
+### Patch Changes
+
+- a9079b4: Improve serve command with syntax highlighting and tabs, add inline field instructions to prompts, rename generatePatches to fill_form, add wire format to session logs, fix table/date/year support in CLI, fix multi_select infinite loop
+
 ## 0.1.8
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary
- Improve serve command with syntax highlighting and tabs
- Add inline field instructions to prompts
- Rename generatePatches tool to fill_form
- Add wire format to session logs for testing
- Fix table/date/year support in CLI
- Fix multi_select infinite loop

## Changes
This is a patch release with improvements to serve command, prompt enhancements, and bug fixes.