### PR TITLE
chore: release markform v0.1.10

### DIFF
--- a/.changeset/v0.1.10.md
+++ b/.changeset/v0.1.10.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Add structured error handling with typed error hierarchy, improve frontmatter parsing using Markdoc native support, add defensive null checks for table rows and patch validation, and significantly improve test coverage to 60%

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.10
+
+### Patch Changes
+
+- 576e19b: Add structured error handling with typed error hierarchy, improve frontmatter parsing using Markdoc native support, add defensive null checks for table rows and patch validation, and significantly improve test coverage to 60%
+
 ## 0.1.9
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary
- Add structured error handling with typed error hierarchy
- Improve frontmatter parsing using Markdoc native support
- Add defensive null checks for table rows and patch validation
- Significantly improve test coverage to 60%

## Release Checklist
- [x] Changeset created
- [x] Version bumped in package.json
- [x] CHANGELOG.md updated
- [x] Tests pass