### PR TITLE
chore: release markform v0.1.11

### DIFF
--- a/.changeset/v0.1.11.md
+++ b/.changeset/v0.1.11.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Support boolean checkbox values, standardize patch property names, and improve error messages

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.11
+
+### Patch Changes
+
+- 8d72787: Support boolean checkbox values, standardize patch property names, and improve error messages
+
 ## 0.1.10
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary
Release v0.1.11

Changes since v0.1.10:
- Support boolean checkbox values
- Standardize patch property names
- Improve checkbox/table error messages and add boolean coercion
- Export serializeReportMarkdown in public API
- Rename serialize functions for clarity