### PR TITLE
chore: release markform v0.1.13

### DIFF
--- a/.changeset/v0.1.13.md
+++ b/.changeset/v0.1.13.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Add best-effort patch application with value coercion, coercion warnings in session files, and increase maxStepsPerTurn default to 20

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.13
+
+### Patch Changes
+
+- 08634fd: Add best-effort patch application with value coercion, coercion warnings in session files, and increase maxStepsPerTurn default to 20
+
 ## 0.1.12
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary
- Add best-effort patch application with value coercion
- Add coercion warnings to session file format
- Increase maxStepsPerTurn default from 3 to 20

## Test plan
- [x] All 1426 tests pass
- [x] lint, typecheck, build, publint all pass