### PR TITLE
fix: add json-summary reporter and badge generation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,12 @@ jobs:
       - run: pnpm publint
       # Run all tests with unified coverage (vitest + tryscript CLI tests)
       - run: pnpm --filter markform test:coverage
+
+      # Generate and commit coverage badges (main branch only)
+      - name: Generate Coverage Badges
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: jpb06/coverage-badges-action@v1.4.6
+        with:
+          coverage-summary-path: packages/markform/coverage/coverage-summary.json
+          output-folder: ./badges/packages/markform
+          branches: main

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -65,7 +65,7 @@
     "test:unit": "vitest run tests/unit",
     "test:golden": "vitest run tests/golden",
     "test:golden:regen": "npx tsx scripts/regen-golden-sessions.ts",
-    "test:coverage": "c8 --src src --all --include 'src/**' --include 'dist/**' --reporter text --reporter html --reports-dir coverage sh -c 'vitest run && tryscript run tests/cli/**/*.tryscript.md'",
+    "test:coverage": "c8 --src src --all --include 'src/**' --include 'dist/**' --reporter text --reporter html --reporter json-summary --reports-dir coverage sh -c 'vitest run && tryscript run tests/cli/**/*.tryscript.md'",
     "test:tryscript": "tryscript run 'tests/cli/**/*.tryscript.md'",
     "test:tryscript:update": "tryscript run --update 'tests/cli/**/*.tryscript.md'",
     "publint": "publint"


### PR DESCRIPTION
## Summary

- Add `json-summary` reporter to c8 coverage command so `coverage-summary.json` is generated
- Add `jpb06/coverage-badges-action` step to CI workflow (runs on main branch pushes only)
- Badges in `./badges/packages/markform/` will now auto-update after merging PRs

## Problem

The coverage badges in the README were showing 61.81% (stale) instead of the current 88.39% coverage. The badge generation step was specified in the coverage implementation spec but never added to the CI workflow.

## Test plan

- [ ] Merge this PR
- [ ] CI runs on main branch push
- [ ] Badge action generates updated badges
- [ ] Badges in README show ~88.39% coverage