### PR TITLE
fix: use no-commit mode for badge action and commit manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,13 @@ jobs:
         with:
           coverage-summary-path: packages/markform/coverage/coverage-summary.json
           output-folder: ./badges/packages/markform
-          branches: main
+          no-commit: true
+
+      - name: Commit Coverage Badges
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add ./badges/packages/markform
+          git diff --staged --quiet || git commit -m "chore: update coverage badges [skip ci]"
+          git push


### PR DESCRIPTION
## Summary

Fix the badge generation CI failure by using `no-commit: true` mode and handling the git commit manually.

## Problem

The `jpb06/coverage-badges-action` was failing with "nothing to commit" because:
1. The action generates badges
2. It then runs `git checkout main` which resets the working directory
3. The generated badges are lost before the commit step

## Solution

- Set `no-commit: true` on the badge action to skip its built-in git operations
- Add a separate step to commit the badges manually
- Use `git diff --staged --quiet || git commit` to only commit if there are changes
- Added `[skip ci]` to the commit message to avoid infinite loops

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, CI generates and commits updated badges
- [ ] README shows correct coverage badge (88.39%)