### PR TITLE
fix: restore original working badge configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,20 @@ jobs:
       # Run all tests with unified coverage (vitest + tryscript CLI tests)
       - run: pnpm --filter markform test:coverage
 
+      # Post coverage report as PR comment
+      - name: Coverage Report
+        uses: davelosert/vitest-coverage-report-action@v2
+        if: always() && github.event_name == 'pull_request'
+        with:
+          json-summary-path: packages/markform/coverage/coverage-summary.json
+          json-final-path: packages/markform/coverage/coverage-final.json
+          file-coverage-mode: changes
+
       # Generate and commit coverage badges (main branch only)
-      - name: Generate Coverage Badges
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      - name: Coverage Badges
         uses: jpb06/coverage-badges-action@v1.4.6
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         with:
           coverage-summary-path: packages/markform/coverage/coverage-summary.json
-          output-folder: ./badges/packages/markform
+          output-folder: ./badges
           branches: main

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -65,7 +65,7 @@
     "test:unit": "vitest run tests/unit",
     "test:golden": "vitest run tests/golden",
     "test:golden:regen": "npx tsx scripts/regen-golden-sessions.ts",
-    "test:coverage": "c8 --src src --all --include 'src/**' --include 'dist/**' --reporter text --reporter html --reporter json-summary --reports-dir coverage sh -c 'vitest run && tryscript run tests/cli/**/*.tryscript.md'",
+    "test:coverage": "c8 --src src --all --include 'src/**' --include 'dist/**' --reporter text --reporter html --reporter json --reporter json-summary --reports-dir coverage sh -c 'vitest run && tryscript run tests/cli/**/*.tryscript.md'",
     "test:tryscript": "tryscript run 'tests/cli/**/*.tryscript.md'",
     "test:tryscript:update": "tryscript run --update 'tests/cli/**/*.tryscript.md'",
     "publint": "publint"


### PR DESCRIPTION
## Summary

Restore the original working badge configuration that was accidentally broken.

## Root Cause

The badge action was working fine before. In commit ae3a177, I incorrectly changed:
- `output-folder: ./badges` → `output-folder: ./badges/packages/markform`

The action creates the subdirectory structure itself based on the coverage-summary-path, so specifying the full path broke it.

## Changes

1. **Restore `output-folder: ./badges`** - the action creates `packages/markform/` subdirectory automatically
2. **Restore PR coverage comment action** - `davelosert/vitest-coverage-report-action@v2` for PR comments
3. **Add `json` reporter to c8** - generates `coverage-final.json` needed by PR comment action

## What was working before (and now restored)

```yaml
- name: Coverage Badges
  uses: jpb06/coverage-badges-action@v1.4.6
  with:
    coverage-summary-path: packages/markform/coverage/coverage-summary.json
    output-folder: ./badges  # NOT ./badges/packages/markform
    branches: main
```

## Test plan

- [ ] CI passes
- [ ] After merge, badges update correctly in `badges/packages/markform/`