### PR TITLE
chore: update README badges to match tryscript format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Markform
 
 [![CI](https://github.com/jlevy/markform/actions/workflows/ci.yml/badge.svg)](https://github.com/jlevy/markform/actions/workflows/ci.yml)
-![Coverage](./badges/packages/markform/coverage-total.svg) [![X (formerly Twitter)
-Follow](https://img.shields.io/twitter/follow/ojoshe)](https://x.com/ojoshe)
+[![Coverage](https://raw.githubusercontent.com/jlevy/markform/main/badges/packages/markform/coverage-total.svg)](https://github.com/jlevy/markform/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/markform)](https://www.npmjs.com/package/markform)
+[![X Follow](https://img.shields.io/twitter/follow/ojoshe)](https://x.com/ojoshe)
 
 **Markform** is a text format for defining structured forms that humans can read,
 machines can parse, and agents can fill via tool calls.


### PR DESCRIPTION
## Summary

Update README badges to be consistent with tryscript repo and more useful:

1. **Coverage badge**: Use raw.githubusercontent.com URL (like tryscript)
2. **Coverage link**: Link to CI workflow instead of the image itself
3. **npm badge**: Added npm version badge
4. **Formatting**: Clean up to one badge per line

## Badge comparison

**Before:**
```markdown
[![CI](...)](...)
![Coverage](./badges/packages/markform/coverage-total.svg) [![X...
```

**After (matches tryscript):**
```markdown
[![CI](...)](...)
[![Coverage](https://raw.githubusercontent.com/.../coverage-total.svg)](CI workflow)
[![npm version](https://img.shields.io/npm/v/markform)](npm page)
[![X Follow](...)](...)
```

## Follow-up consideration

The coverage badge currently links to the CI workflow page. For a more useful link, we could:
- Deploy coverage HTML to GitHub Pages (stable URL to detailed report)
- Use Codecov/Coveralls (external service with coverage history)

For now, linking to CI is pragmatic - users can click into any run to see the coverage summary.