### PR TITLE
feat: deploy coverage report to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment to GitHub Pages
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -47,3 +54,39 @@ jobs:
           coverage-summary-path: packages/markform/coverage/coverage-summary.json
           output-folder: ./badges
           branches: main
+
+      # Upload coverage report for GitHub Pages deployment
+      - name: Upload coverage artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-report
+          path: packages/markform/coverage
+          retention-days: 30
+
+  # Deploy coverage report to GitHub Pages (main branch only)
+  deploy-coverage:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: coverage-report
+          path: ./coverage
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./coverage
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Markform
 
 [![CI](https://github.com/jlevy/markform/actions/workflows/ci.yml/badge.svg)](https://github.com/jlevy/markform/actions/workflows/ci.yml)
-[![Coverage](https://raw.githubusercontent.com/jlevy/markform/main/badges/packages/markform/coverage-total.svg)](https://github.com/jlevy/markform/actions/workflows/ci.yml)
+[![Coverage](https://raw.githubusercontent.com/jlevy/markform/main/badges/packages/markform/coverage-total.svg)](https://jlevy.github.io/markform/)
 [![npm version](https://img.shields.io/npm/v/markform)](https://www.npmjs.com/package/markform)
 [![X Follow](https://img.shields.io/twitter/follow/ojoshe)](https://x.com/ojoshe)
 


### PR DESCRIPTION
## Summary

Deploy the HTML coverage report to GitHub Pages, providing a stable, browsable URL for detailed file-by-file coverage information.

## Is this common?

Yes! Using GitHub Pages just for engineering reports (coverage, API docs) is a common pattern in open source:

- [Auto-Publish Coverage to GitHub Pages](https://dev.to/mbarzeev/auto-publish-your-test-coverage-report-on-github-pages-35be) - Popular tutorial
- Many projects use this approach before (or instead of) building a full website
- It's "free" infrastructure that grows with you - start with coverage, add API docs later

The coverage report is self-contained HTML, so it doesn't conflict with future website plans. You could later add:
- `/coverage/` - Coverage report (this PR)
- `/api/` - TypeDoc API documentation  
- `/` - Project website (if desired)

## Changes

1. **New `deploy-coverage` job** - Runs after tests, deploys to GitHub Pages
2. **Artifact passing** - Coverage uploaded from test job, downloaded in deploy job
3. **Permissions** - Added `pages: write` and `id-token: write`
4. **Concurrency** - Prevents conflicting deployments
5. **README update** - Coverage badge now links to GitHub Pages

## After merge

Coverage will be available at: **https://jlevy.github.io/markform/**

### Required setup

GitHub Pages must be enabled in repo settings:
1. Go to Settings → Pages
2. Source: **GitHub Actions** (not "Deploy from branch")

## How it works

```
test job:
  → runs tests with coverage
  → uploads coverage artifact

deploy-coverage job:
  → downloads coverage artifact  
  → deploys to GitHub Pages
```

## Test plan

- [ ] CI passes (test job)
- [ ] Deploy job runs on main merge
- [ ] Coverage accessible at https://jlevy.github.io/markform/
- [ ] Coverage badge links to GitHub Pages