### PR TITLE
fix: add working-directory to vitest-coverage-report-action for monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,10 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@v2
         if: always()
         with:
-          json-summary-path: packages/markform/coverage/coverage-summary.json
-          json-final-path: packages/markform/coverage/coverage-final.json
+          # Working directory for monorepo support - action looks for vite config and coverage files here
+          working-directory: packages/markform
+          json-summary-path: coverage/coverage-summary.json
+          json-final-path: coverage/coverage-final.json
           # Only show changed files on PRs, show all on main
           file-coverage-mode: ${{ github.event_name == 'pull_request' && 'changes' || 'all' }}
 


### PR DESCRIPTION
## Summary
- Fixed the vitest-coverage-report-action configuration to work with this monorepo structure
- The action was failing to find the vitest config file because it was looking in the root directory instead of `packages/markform`
- This caused the coverage report to not appear in the GitHub Actions job summary, making the coverage badge link useless

## Changes
- Added `working-directory: packages/markform` to the Coverage Report step
- Adjusted `json-summary-path` and `json-final-path` to be relative to the working directory

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Check that the Coverage Report step no longer shows the vite config warning
- [ ] Verify that the PR gets a coverage comment with actual coverage data
- [ ] After merging, verify the coverage badge link shows the coverage report