### PR TITLE
test: improve coverage with urlFormat and shared utility tests

### DIFF
--- a/packages/markform/tests/unit/cli/shared.test.ts
+++ b/packages/markform/tests/unit/cli/shared.test.ts
@@ -4,8 +4,15 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { formatPath, createNoOpSpinner, OUTPUT_FORMATS } from '../../../src/cli/lib/shared.js';
+import {
+  formatPath,
+  createNoOpSpinner,
+  OUTPUT_FORMATS,
+  formatOutput,
+  shouldUseColors,
+} from '../../../src/cli/lib/shared.js';
 import { stripAnsi } from '../../utils/ansi.js';
+import type { CommandContext } from '../../../src/cli/lib/cliTypes.js';
 
 describe('shared utilities', () => {
   it('OUTPUT_FORMATS includes all expected formats', () => {
@@ -66,6 +73,70 @@ describe('shared utilities', () => {
       expect(start).toBeGreaterThanOrEqual(0);
       await new Promise((r) => setTimeout(r, 50));
       expect(spinner.getElapsedMs()).toBeGreaterThan(start);
+    });
+  });
+
+  describe('formatOutput', () => {
+    const baseCtx: CommandContext = {
+      dryRun: false,
+      verbose: false,
+      quiet: false,
+      format: 'console',
+      overwrite: false,
+    };
+
+    it('formats data as JSON with snake_case keys', () => {
+      const ctx = { ...baseCtx, format: 'json' as const };
+      const data = { fieldName: 'value', nestedObj: { innerKey: 123 } };
+      const result = formatOutput(ctx, data);
+      expect(JSON.parse(result)).toEqual({
+        field_name: 'value',
+        nested_obj: { inner_key: 123 },
+      });
+    });
+
+    it('formats data as YAML with snake_case keys', () => {
+      const ctx = { ...baseCtx, format: 'yaml' as const };
+      const data = { fieldName: 'value' };
+      const result = formatOutput(ctx, data);
+      expect(result).toContain('field_name: value');
+    });
+
+    it('uses console formatter when provided', () => {
+      const ctx = { ...baseCtx, format: 'console' as const };
+      const data = { test: true };
+      const formatter = (d: unknown, _useColors: boolean) => `Custom: ${JSON.stringify(d)}`;
+      const result = formatOutput(ctx, data, formatter);
+      expect(result).toBe('Custom: {"test":true}');
+    });
+
+    it('falls back to YAML for console format without formatter', () => {
+      const ctx = { ...baseCtx, format: 'console' as const };
+      const data = { testValue: 42 };
+      const result = formatOutput(ctx, data);
+      expect(result).toContain('test_value: 42');
+    });
+  });
+
+  describe('shouldUseColors', () => {
+    const baseCtx: CommandContext = {
+      dryRun: false,
+      verbose: false,
+      quiet: false,
+      format: 'console',
+      overwrite: false,
+    };
+
+    it('returns false for json format', () => {
+      expect(shouldUseColors({ ...baseCtx, format: 'json' })).toBe(false);
+    });
+
+    it('returns false for yaml format', () => {
+      expect(shouldUseColors({ ...baseCtx, format: 'yaml' })).toBe(false);
+    });
+
+    it('returns false for plaintext format', () => {
+      expect(shouldUseColors({ ...baseCtx, format: 'plaintext' })).toBe(false);
     });
   });
 });

--- a/packages/markform/tests/unit/utils/urlFormat.test.ts
+++ b/packages/markform/tests/unit/utils/urlFormat.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for URL formatting utilities.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  extractDomain,
+  friendlyUrlAbbrev,
+  formatUrlAsMarkdownLink,
+  isUrl,
+} from '../../../src/utils/urlFormat.js';
+
+describe('urlFormat', () => {
+  describe('extractDomain', () => {
+    // [input, expected]
+    const cases: [string, string][] = [
+      ['https://example.com/path', 'example.com'],
+      ['http://www.example.com/path', 'www.example.com'],
+      ['https://sub.example.com:8080/path', 'sub.example.com'],
+      ['example.com/path', 'example.com'],
+      // www. is stripped by the regex fallback for non-URL strings
+      ['www.example.com/path', 'example.com'],
+      // Fallback regex extracts first domain-like pattern
+      ['invalid string', 'invalid'],
+      ['', ''],
+    ];
+
+    it.each(cases)('extractDomain(%s) → %s', (input, expected) => {
+      expect(extractDomain(input)).toBe(expected);
+    });
+  });
+
+  describe('friendlyUrlAbbrev', () => {
+    it('returns hostname only for URLs without path', () => {
+      expect(friendlyUrlAbbrev('https://example.com')).toBe('example.com');
+      expect(friendlyUrlAbbrev('https://example.com/')).toBe('example.com');
+    });
+
+    it('removes www. prefix', () => {
+      expect(friendlyUrlAbbrev('https://www.example.com')).toBe('example.com');
+      expect(friendlyUrlAbbrev('https://www.example.com/docs')).toBe('example.com/docs');
+    });
+
+    it('includes short paths in full', () => {
+      expect(friendlyUrlAbbrev('https://example.com/docs')).toBe('example.com/docs');
+      expect(friendlyUrlAbbrev('https://example.com/api/v1')).toBe('example.com/api/v1');
+    });
+
+    it('truncates long paths with ellipsis', () => {
+      const result = friendlyUrlAbbrev('https://example.com/this/is/a/very/long/path');
+      expect(result).toBe('example.com/this/is/a/ve…');
+      expect(result.length).toBeLessThan(30);
+    });
+
+    it('respects custom maxPathChars', () => {
+      expect(friendlyUrlAbbrev('https://example.com/abcdefghij', 5)).toBe('example.com/abcde…');
+      expect(friendlyUrlAbbrev('https://example.com/abcde', 5)).toBe('example.com/abcde');
+    });
+
+    it('handles invalid URLs gracefully', () => {
+      expect(friendlyUrlAbbrev('not-a-url')).toBe('not-a-url');
+      expect(friendlyUrlAbbrev('http://www.example.com')).toBe('example.com');
+    });
+
+    it('handles very long invalid strings', () => {
+      const longStr = 'a'.repeat(50);
+      const result = friendlyUrlAbbrev(longStr);
+      expect(result.length).toBeLessThanOrEqual(31); // 30 + ellipsis
+    });
+  });
+
+  describe('formatUrlAsMarkdownLink', () => {
+    it('creates markdown link with friendly display text', () => {
+      expect(formatUrlAsMarkdownLink('https://example.com/docs')).toBe(
+        '[example.com/docs](https://example.com/docs)',
+      );
+    });
+
+    it('preserves full URL in href', () => {
+      const fullUrl = 'https://www.example.com/very/long/path/to/resource';
+      const result = formatUrlAsMarkdownLink(fullUrl);
+      expect(result).toContain(`](${fullUrl})`);
+    });
+  });
+
+  describe('isUrl', () => {
+    // [input, expected]
+    const cases: [string, boolean][] = [
+      ['https://example.com', true],
+      ['http://example.com', true],
+      ['www.example.com', true],
+      ['example.com', false],
+      ['not a url', false],
+      ['ftp://example.com', false],
+      ['', false],
+    ];
+
+    it.each(cases)('isUrl(%s) → %s', (input, expected) => {
+      expect(isUrl(input)).toBe(expected);
+    });
+  });
+});

--- a/packages/markform/vitest.config.ts
+++ b/packages/markform/vitest.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
         '**/commands/browse.ts',
         '**/commands/run.ts',
         '**/commands/research.ts',
+        // Research integration code (requires live API access)
+        '**/research/runResearch.ts',
       ],
       // Thresholds based on current coverage (~60%); will increase as coverage improves
       thresholds: {


### PR DESCRIPTION
## Summary
- Add comprehensive tests for urlFormat.ts (extractDomain, friendlyUrlAbbrev, formatUrlAsMarkdownLink, isUrl): achieves 100% coverage
- Add formatOutput and shouldUseColors tests to shared.test.ts
- Exclude runResearch.ts from coverage (integration code requiring live API access)

## Coverage improvements
- urlFormat.ts: 37% → 100%
- shared.ts: improved with formatOutput tests
- Overall coverage continues to pass 60%+ thresholds

## Test plan
- [x] All 1486 tests pass
- [x] Coverage thresholds met
- [x] Pre-commit hooks pass (format, typecheck, lint)