### PR TITLE
chore: release markform v0.1.15

### DIFF
--- a/.changeset/v0.1.15.md
+++ b/.changeset/v0.1.15.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Unified test coverage, URL formatting improvements, and documentation updates

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.15
+
+### Patch Changes
+
+- 34fd531: Unified test coverage, URL formatting improvements, and documentation updates
+
 ## 0.1.14
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## What's Changed

### Features

- **Unified test coverage**: Integrated vitest and tryscript coverage into a single report with merged LCOV output
- **URL formatting improvements**: URLs display as domain links with hover-to-copy functionality in web view
- **Web UI enhancements**: Added View/Source tabs and improved tab interface with print CSS support
- **Resumable form fills**: Support for saving and resuming form fill sessions
- **Boolean checkbox values**: Standardized boolean value handling for checkbox fields

### Fixes

- Fixed tooltip positioning and visibility in web UI
- Fixed checkbox and multi-select consistency in reports
- Fixed coverage exclusion patterns for monorepo configuration
- Stripped HTML comments from docs commands output
- Updated badge links to reference specific CI runs

### Refactoring

- Converted CLI integration tests to tryscript format
- Rewrote coverage merge script in TypeScript
- Extracted testable helpers from interactive CLI commands

### Documentation

- Added release notes process with format guide and examples
- Added CC-BY-4.0 license for spec and CLA for contributors
- Added research briefs on subforms and coverage infrastructure

**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.14...claude/release-0.1.15-aFOBm