### PR TITLE
chore: release markform v0.1.16

### DIFF
--- a/.changeset/v0.1.16.md
+++ b/.changeset/v0.1.16.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Add HTML comment syntax as a cleaner alternative to Markdoc tags, making forms render as valid Markdown on GitHub while maintaining full backward compatibility with existing tag syntax

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.16
+
+### Patch Changes
+
+- 97390e0: Add HTML comment syntax as a cleaner alternative to Markdoc tags, making forms render as valid Markdown on GitHub while maintaining full backward compatibility with existing tag syntax
+
 ## 0.1.15
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## What's Changed

### Features

- **HTML comment syntax**: Forms can now use `<!-- form -->` instead of `{% form %}`, making them render as clean, valid Markdown on GitHub while remaining fully functional
- **Scoped transformation**: Comment syntax is only processed within form boundaries, preventing collisions with regular HTML comments
- **`--syntax` validation option**: New CLI option to enforce consistent syntax usage (comments or tags)

### Documentation

- HTML comment syntax is now primary in all documentation and examples
- Added comprehensive research briefs and implementation specs

### Backward Compatibility

Full backward compatibility with existing Markdoc tag syntax (`{% form %}`, `{% field %}`, etc.) - all existing forms continue to work unchanged.

**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.15...v0.1.16