### PR TITLE
chore(deps): upgrade tryscript to ^0.1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,23 +31,25 @@ jobs:
       - run: pnpm --filter markform test:coverage
 
       # Post coverage report (PR comment + job summary)
+      # Uses merged coverage from tryscript (vitest + tryscript CLI tests combined)
       - name: Coverage Report
         uses: davelosert/vitest-coverage-report-action@v2
         if: always()
         with:
           # Working directory for monorepo support - action looks for vite config and coverage files here
           working-directory: packages/markform
-          json-summary-path: coverage/coverage-summary.json
+          json-summary-path: coverage-tryscript/coverage-summary.json
           json-final-path: coverage/coverage-final.json
           # Only show changed files on PRs, show all on main
           file-coverage-mode: ${{ github.event_name == 'pull_request' && 'changes' || 'all' }}
 
       # Generate and commit coverage badges (main branch only)
+      # Uses merged coverage from tryscript (vitest + tryscript CLI tests combined)
       - name: Coverage Badges
         uses: jpb06/coverage-badges-action@v1.4.6
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         with:
-          coverage-summary-path: packages/markform/coverage/coverage-summary.json
+          coverage-summary-path: packages/markform/coverage-tryscript/coverage-summary.json
           output-folder: ./badges
           branches: main
 

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -98,7 +98,7 @@
     "c8": "^10.1.3",
     "monocart-coverage-reports": "^2.12.9",
     "publint": "^0.3.16",
-    "tryscript": "^0.1.4",
+    "tryscript": "^0.1.6",
     "tsdown": "^0.18.3",
     "typescript": "^5.9.3",
     "vitest": "^4.0.16"


### PR DESCRIPTION
## Summary

Upgrade tryscript from ^0.1.4 to ^0.1.6 and fix CI to use merged coverage.

### Changes

1. **Upgrade tryscript to ^0.1.6** - Gets the latest bug fixes and improvements
2. **Fix CI to use merged coverage** - Change coverage paths from `coverage/` to `coverage-tryscript/`:
   - Coverage Report action now reads from `coverage-tryscript/coverage-summary.json`
   - Coverage Badges action now reads from `coverage-tryscript/coverage-summary.json`

### Why this matters

Previously, CI was reading from `coverage/` which only contains vitest's unit test coverage. The merged coverage (vitest + tryscript CLI tests) is written to `coverage-tryscript/` by tryscript's `--merge-lcov` feature. This fix ensures badges and reports show the complete coverage.

## Test plan

- [ ] CI passes with new tryscript version
- [ ] Coverage report shows merged values
- [ ] Coverage badges reflect merged coverage