### PR TITLE
chore: release markform v0.1.18

### DIFF
--- a/.changeset/v0.1.18.md
+++ b/.changeset/v0.1.18.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Add parallel form filling with plan command, ParallelHarness, and order/parallel attributes

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.18
+
+### Patch Changes
+
+- 28696dc: Add parallel form filling with plan command, ParallelHarness, and order/parallel attributes
+
 ## 0.1.17
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## What's Changed

### Features

- **Parallel form filling**: Added `parallel` and `order` attributes to markform engine for concurrent field processing
- **Plan command**: New `plan` command that generates an idealized fill-sequence plan for forms
- **ParallelHarness**: Phase 3 concurrent agent execution harness with configurable `max_parallel_agents`
- **Unified fillForm() spec**: Phase 4 spec for unified `fillForm()` with opt-in parallel execution

### Fixes

- Updated CLI snapshot for plan command
- Enforced snake_case YAML keys in harness configuration
- Added validation for nested field tags

### Documentation

- Comprehensive parallel filling spec across four implementation phases
- Harness configuration documentation in spec and reference
- Order attribute semantics and parallel batch rules

### Chores

- Upgraded tbd to v0.1.8

**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.17...v0.1.18
