### PR TITLE
fix: preserve URLs in table cells during AST parsing and serialization

### DIFF
--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -15,6 +15,7 @@ display:
 docs_cache:
   files:
     guidelines/backward-compatibility-rules.md: internal:guidelines/backward-compatibility-rules.md
+    guidelines/bun-monorepo-patterns.md: internal:guidelines/bun-monorepo-patterns.md
     guidelines/cli-agent-skill-patterns.md: internal:guidelines/cli-agent-skill-patterns.md
     guidelines/commit-conventions.md: internal:guidelines/commit-conventions.md
     guidelines/convex-limits-best-practices.md: internal:guidelines/convex-limits-best-practices.md
@@ -27,15 +28,16 @@ docs_cache:
     guidelines/general-tdd-guidelines.md: internal:guidelines/general-tdd-guidelines.md
     guidelines/general-testing-rules.md: internal:guidelines/general-testing-rules.md
     guidelines/golden-testing-guidelines.md: internal:guidelines/golden-testing-guidelines.md
+    guidelines/pnpm-monorepo-patterns.md: internal:guidelines/pnpm-monorepo-patterns.md
     guidelines/python-cli-patterns.md: internal:guidelines/python-cli-patterns.md
     guidelines/python-modern-guidelines.md: internal:guidelines/python-modern-guidelines.md
     guidelines/python-rules.md: internal:guidelines/python-rules.md
     guidelines/release-notes-guidelines.md: internal:guidelines/release-notes-guidelines.md
-    guidelines/sync-troubleshooting.md: internal:guidelines/sync-troubleshooting.md
+    guidelines/tbd-sync-troubleshooting.md: internal:guidelines/tbd-sync-troubleshooting.md
     guidelines/typescript-cli-tool-rules.md: internal:guidelines/typescript-cli-tool-rules.md
     guidelines/typescript-code-coverage.md: internal:guidelines/typescript-code-coverage.md
-    guidelines/typescript-monorepo-patterns.md: internal:guidelines/typescript-monorepo-patterns.md
     guidelines/typescript-rules.md: internal:guidelines/typescript-rules.md
+    guidelines/typescript-sorting-patterns.md: internal:guidelines/typescript-sorting-patterns.md
     guidelines/typescript-yaml-handling-rules.md: internal:guidelines/typescript-yaml-handling-rules.md
     shortcuts/standard/agent-handoff.md: internal:shortcuts/standard/agent-handoff.md
     shortcuts/standard/checkout-third-party-repo.md: internal:shortcuts/standard/checkout-third-party-repo.md
@@ -43,6 +45,7 @@ docs_cache:
     shortcuts/standard/code-cleanup-docstrings.md: internal:shortcuts/standard/code-cleanup-docstrings.md
     shortcuts/standard/code-cleanup-tests.md: internal:shortcuts/standard/code-cleanup-tests.md
     shortcuts/standard/code-review-and-commit.md: internal:shortcuts/standard/code-review-and-commit.md
+    shortcuts/standard/coding-spike.md: internal:shortcuts/standard/coding-spike.md
     shortcuts/standard/create-or-update-pr-simple.md: internal:shortcuts/standard/create-or-update-pr-simple.md
     shortcuts/standard/create-or-update-pr-with-validation-plan.md: internal:shortcuts/standard/create-or-update-pr-with-validation-plan.md
     shortcuts/standard/implement-beads.md: internal:shortcuts/standard/implement-beads.md

--- a/packages/markform/src/engine/parseHelpers.ts
+++ b/packages/markform/src/engine/parseHelpers.ts
@@ -284,6 +284,11 @@ export function extractTableContent(node: Node): string | null {
     if (n.type === 'text' && typeof n.attributes?.content === 'string') {
       return n.attributes.content;
     }
+    // Handle link nodes - reconstruct as markdown link [text](url)
+    if (n.type === 'link' && typeof n.attributes?.href === 'string') {
+      const linkText = n.children?.map(extractTextFromNode).join('') ?? '';
+      return `[${linkText}](${n.attributes.href})`;
+    }
     if (n.children && Array.isArray(n.children)) {
       return n.children.map(extractTextFromNode).join('');
     }

--- a/packages/markform/src/engine/serialize.ts
+++ b/packages/markform/src/engine/serialize.ts
@@ -1070,9 +1070,9 @@ function serializeYearField(field: YearField, response: FieldResponse | undefine
 
 /**
  * Serialize a cell value for table output.
- * URL-typed columns are formatted as markdown links with domain as display text.
+ * Values are serialized as-is; HTML rendering handles display formatting.
  */
-function serializeCellValue(cell: CellResponse, columnType: ColumnTypeName): string {
+function serializeCellValue(cell: CellResponse, _columnType: ColumnTypeName): string {
   if (cell.state === 'skipped') {
     return cell.reason ? `%SKIP:${cell.reason}%` : '%SKIP%';
   }
@@ -1086,10 +1086,8 @@ function serializeCellValue(cell: CellResponse, columnType: ColumnTypeName): str
   if (typeof cell.value === 'number') {
     return String(cell.value);
   }
-  // Format URL columns as markdown links
-  if (columnType === 'url') {
-    return formatUrlAsMarkdownLink(cell.value);
-  }
+  // URL columns: keep bare URL for round-trip safety
+  // (HTML rendering handles abbreviated display via formatBareUrlsAsHtmlLinks)
   return cell.value;
 }
 

--- a/packages/markform/tests/unit/engine/validate.test.ts
+++ b/packages/markform/tests/unit/engine/validate.test.ts
@@ -1444,6 +1444,81 @@ markform:
 
       expect(result.isValid).toBe(true);
     });
+
+    it('validates URL columns with bare URLs', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% group id="g1" %}
+{% field kind="table" id="sources" label="Sources" columnIds=["name", "url"] columnTypes=["string", "url"] %}
+| name | url |
+|------|-----|
+| Example | https://example.com |
+{% /field %}
+{% /group %}
+
+{% /form %}
+`;
+      const form = parseForm(markdown);
+      const result = validate(form);
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('validates URL columns with markdown link format', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% group id="g1" %}
+{% field kind="table" id="sources" label="Sources" columnIds=["name", "url"] columnTypes=["string", "url"] %}
+| name | url |
+|------|-----|
+| SEC Filing | [sec.gov/Archives/edg…](https://www.sec.gov/Archives/edgar/data/1326801) |
+{% /field %}
+{% /group %}
+
+{% /form %}
+`;
+      const form = parseForm(markdown);
+      const result = validate(form);
+
+      // Should pass - the URL is extracted from the markdown link
+      expect(result.isValid).toBe(true);
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it('rejects invalid URLs in URL columns', () => {
+      const markdown = `---
+markform:
+  spec: MF/0.1
+---
+
+{% form id="test" %}
+
+{% group id="g1" %}
+{% field kind="table" id="sources" label="Sources" columnIds=["name", "url"] columnTypes=["string", "url"] %}
+| name | url |
+|------|-----|
+| Invalid | not-a-valid-url |
+{% /field %}
+{% /group %}
+
+{% /form %}
+`;
+      const form = parseForm(markdown);
+      const result = validate(form);
+
+      expect(result.isValid).toBe(false);
+      expect(result.issues[0]?.message).toContain('must be a valid URL');
+    });
   });
 
   describe('group validators', () => {


### PR DESCRIPTION
## Summary

- Fixes bug where URL validation incorrectly checked link text instead of actual URL when table cells contained markdown links
- URLs like `[sec.gov/Archives/edg…](https://www.sec.gov/...)` were having their abbreviated display text validated instead of the actual URL
- Root cause: When Markdoc parses markdown, link nodes lose the URL; `extractTableContent` now reconstructs them as `[text](url)`
- Also simplified URL serialization to keep bare URLs (HTML handles display formatting)

## Test plan

- [x] Added test: validates URL columns with bare URLs
- [x] Added test: validates URL columns with markdown link format
- [x] Added test: rejects invalid URLs in URL columns
- [x] All 2037 tests pass

https://claude.ai/code/session_01TXYVK4M9sAmpAW9p4LXtb5