### PR TITLE
chore: release markform v0.1.22 (expose form/fill rendering, other small cleanups)

### DIFF
--- a/.changeset/v0.1.22.md
+++ b/.changeset/v0.1.22.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Render subpath export, skip reason display, URL parsing fix, API error improvements

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.22
+
+### Patch Changes
+
+- a8738d4: Render subpath export, skip reason display, URL parsing fix, API error improvements
+
 ## 0.1.21
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## What's Changed

### Features

- **Render subpath export**: New `markform/render` subpath exports rendering functions (`renderViewContent`, `renderSourceContent`, `renderFillRecordContent`, etc.) so external consumers can render forms with visual parity to `markform serve` without CLI/server dependencies
- **Twitter thread example**: New content transformation example form for Twitter thread workflows

### Fixes

- **Skip reason display**: Skip reasons from agents (e.g., "Not applicable") now display correctly in View, Edit, and Report tabs of the serve UI
- **URL preservation in tables**: Fixed URL validation in table cells that incorrectly checked link display text instead of the actual URL, causing valid URLs to be rejected
- **API error messages**: Improved error context for model API failures with HTTP status codes, response bodies, and actionable troubleshooting hints

### Refactoring

- Extracted ~1600 lines of rendering code from `serve.ts` into dedicated `src/render/` module

**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.21...v0.1.22
