### PR TITLE
fix: show skip reason only in field content, not in badge pill

### DIFF
--- a/packages/markform/src/cli/commands/serve.ts
+++ b/packages/markform/src/cli/commands/serve.ts
@@ -942,6 +942,12 @@ export function renderFormHtml(form: ParsedForm, tabs?: Tab[] | null): string {
       border-radius: 3px;
       margin-left: 0.5rem;
     }
+    .skip-reason {
+      font-size: 0.85rem;
+      color: #6c757d;
+      font-style: italic;
+      margin-top: 0.25rem;
+    }
     .table-container {
       overflow-x: auto;
     }
@@ -1328,8 +1334,11 @@ export function renderFieldHtml(
   const skipped = isSkipped === true;
   const requiredMark = field.required ? '<span class="required">*</span>' : '';
   const typeLabel = `<span class="type-badge">${field.kind}</span>`;
-  const skippedText = skipped && skipReason ? `Skipped: ${escapeHtml(skipReason)}` : 'Skipped';
-  const skippedBadge = skipped ? `<span class="skipped-badge">${skippedText}</span>` : '';
+  const skippedBadge = skipped ? `<span class="skipped-badge">Skipped</span>` : '';
+  const skipReasonHtml =
+    skipped && skipReason
+      ? `<div class="skip-reason">(skipped: ${escapeHtml(skipReason)})</div>`
+      : '';
   const fieldClass = skipped ? 'field field-skipped' : 'field';
   const disabledAttr = skipped ? ' disabled' : '';
 
@@ -1398,6 +1407,7 @@ export function renderFieldHtml(
         ${escapeHtml(field.label)} ${requiredMark} ${typeLabel} ${skippedBadge}
       </label>
       ${inputHtml}
+      ${skipReasonHtml}
       ${skipButton}
     </div>`;
 }

--- a/packages/markform/src/render/contentRenderers.ts
+++ b/packages/markform/src/render/contentRenderers.ts
@@ -223,8 +223,7 @@ export function renderViewContent(form: ParsedForm): string {
         html += ' <span class="required">*</span>';
       }
       if (isSkipped) {
-        const reasonText = skipReason ? `Skipped: ${escapeHtml(skipReason)}` : 'Skipped';
-        html += ` <span class="skipped-badge">${reasonText}</span>`;
+        html += ` <span class="skipped-badge">Skipped</span>`;
       }
       html += '</div>';
 

--- a/packages/markform/tests/unit/web/serve-render.test.ts
+++ b/packages/markform/tests/unit/web/serve-render.test.ts
@@ -935,8 +935,9 @@ markform:
         };
         const html = renderFormHtml(form);
 
-        expect(html).toContain('Not applicable');
-        expect(html).toContain('skipped-badge');
+        expect(html).toContain('skipped-badge">Skipped</span>');
+        expect(html).toContain('skip-reason');
+        expect(html).toContain('(skipped: Not applicable)');
       });
     });
   });
@@ -1262,14 +1263,15 @@ John Doe
       expect(html).toContain('(skipped: Not applicable to this company)');
     });
 
-    it('should show skip reason in skipped badge when reason is provided', () => {
+    it('should show skipped badge without reason text', () => {
       const form = parseForm(formContent);
       form.responsesByFieldId = {
         name: { state: 'skipped', reason: 'Field not relevant' },
       };
       const html = renderViewContent(form);
       expect(html).toContain('skipped-badge');
-      expect(html).toContain('Field not relevant');
+      expect(html).not.toContain('skipped-badge">Skipped: Field not relevant');
+      expect(html).toContain('skipped-badge">Skipped</span>');
     });
 
     it('should render single_select with selected option label', () => {


### PR DESCRIPTION
## Summary

The "Skipped" badge/pill in the serve UI was including the full skip reason text, making it oversized and ugly. This fix keeps the badge as a compact "Skipped" pill and shows the reason only in the field content area below, where it already appeared in parentheses (View tab) or is now added as a styled note (Edit tab).

## Changes

- **View tab** (`contentRenderers.ts`): Changed skipped badge to always render just "Skipped" instead of "Skipped: <reason>". The reason was already displayed in the field value as `(skipped: reason)`, so it was being duplicated.
- **Edit tab** (`serve.ts`): Same badge fix — always just "Skipped". Added a new `.skip-reason` div that renders the reason as a styled italic note below the input field.
- **CSS** (`serve.ts`): Added `.skip-reason` class with smaller italic gray text styling.
- **Tests** (`serve-render.test.ts`): Updated tests to verify badges contain only "Skipped" and that the reason appears separately in the field content.

## Test Plan

- [x] Unit tests pass (`pnpm test` — 2063 passed)
- [x] Lint and typecheck pass (`pnpm lint`)
- [x] Pre-commit hooks pass (format, typecheck, lint)
- [ ] Manual testing: Load a form with skipped fields in serve UI
  - [ ] View tab: "Skipped" pill is compact, reason appears only in `(skipped: ...)` below
  - [ ] Edit tab: "Skipped" pill is compact, reason appears as italic note below input
  - [ ] Fields without a skip reason still show just "Skipped" pill and `(skipped)` text
  - [ ] Table cells still show `[skipped: reason]` format (unchanged)
- [ ] Edge cases:
  - [ ] Very long skip reasons don't overflow the field content area
  - [ ] HTML special characters in skip reasons are properly escaped
  - [ ] Fields with no skip reason render the same as before

https://claude.ai/code/session_0158oKXAPaTdXiGj1jMaXgrk