### PR TITLE
chore: release markform v0.1.23

### DIFF
--- a/.changeset/v0.1.23.md
+++ b/.changeset/v0.1.23.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Extensible provider support via ProviderAdapter; fix skip reason display in badge pill

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.23
+
+### Patch Changes
+
+- 5ed47e2: Extensible provider support via ProviderAdapter; fix skip reason display in badge pill
+
 ## 0.1.22
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## What's Changed

### Features

- **Extensible provider support**: New `ProviderAdapter` interface allows custom AI SDK providers beyond the 5 built-in ones. Pass custom providers via `FillOptions.providers` for per-call resolution with full tool support.
- **Pure model ID parsing**: `parseModelId()` is now a pure format parser; any `provider/model-id` string parses successfully. Provider validation moves to `resolveModel()`.
- **Provider utilities**: New `normalizeProvider()`, `extractToolsFromProvider()`, and `BUILT_IN_PROVIDERS` exports for working with custom and built-in providers.

### Fixes

- Fixed skip reason displaying in badge pill instead of only in field content

**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.22...v0.1.23
