### PR TITLE
fix: preserve fillForm error diagnostics and callbacks (#142)

### DIFF
--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -40,6 +40,7 @@ docs_cache:
     guidelines/typescript-rules.md: internal:guidelines/typescript-rules.md
     guidelines/typescript-sorting-patterns.md: internal:guidelines/typescript-sorting-patterns.md
     guidelines/typescript-yaml-handling-rules.md: internal:guidelines/typescript-yaml-handling-rules.md
+    guidelines/writing-style-guidelines.md: internal:guidelines/writing-style-guidelines.md
     shortcuts/standard/agent-handoff.md: internal:shortcuts/standard/agent-handoff.md
     shortcuts/standard/checkout-third-party-repo.md: internal:shortcuts/standard/checkout-third-party-repo.md
     shortcuts/standard/code-cleanup-all.md: internal:shortcuts/standard/code-cleanup-all.md
@@ -54,6 +55,7 @@ docs_cache:
     shortcuts/standard/new-architecture-doc.md: internal:shortcuts/standard/new-architecture-doc.md
     shortcuts/standard/new-guideline.md: internal:shortcuts/standard/new-guideline.md
     shortcuts/standard/new-plan-spec.md: internal:shortcuts/standard/new-plan-spec.md
+    shortcuts/standard/new-qa-playbook.md: internal:shortcuts/standard/new-qa-playbook.md
     shortcuts/standard/new-research-brief.md: internal:shortcuts/standard/new-research-brief.md
     shortcuts/standard/new-shortcut.md: internal:shortcuts/standard/new-shortcut.md
     shortcuts/standard/new-validation-plan.md: internal:shortcuts/standard/new-validation-plan.md
@@ -75,6 +77,7 @@ docs_cache:
     shortcuts/system/skill-minimal.md: internal:shortcuts/system/skill-minimal.md
     templates/architecture-doc.md: internal:templates/architecture-doc.md
     templates/plan-spec.md: internal:templates/plan-spec.md
+    templates/qa-playbook.md: internal:templates/qa-playbook.md
     templates/research-brief.md: internal:templates/research-brief.md
   lookup_path:
     - .tbd/docs/shortcuts/system

--- a/docs/project/specs/active/plan-2026-02-14-fill-error-diagnostics.md
+++ b/docs/project/specs/active/plan-2026-02-14-fill-error-diagnostics.md
@@ -1,0 +1,98 @@
+# Feature: fillForm Error Diagnostics and Callback Contract (#142)
+
+**Date:** 2026-02-14 (last updated 2026-02-14)
+
+**Author:** Codex (GPT-5)
+
+**Status:** Implemented (pending merge)
+
+## Overview
+
+Issue #142 reports that `fillForm()` dropped structured error objects and only returned string
+messages. This spec defines and records the landed fix (`FillStatus.error` + `onError` callback),
+including follow-up validation and docs parity.
+
+## Goals
+
+- Preserve original `Error` objects for `reason: 'error'` outcomes in `FillResult.status`.
+- Provide real-time error reporting through `FillCallbacks.onError` during fill-loop execution.
+- Verify serial and parallel paths behave consistently.
+- Align public API docs with the shipped TypeScript contract.
+
+## Non-Goals
+
+- Serializing full `Error` objects into `FillRecord` JSON sidecars.
+- Changing retry policy or provider-specific error wrapping.
+- Redesigning all callback contracts beyond `onError` behavior.
+
+## Background
+
+`fillForm()` can fail from agent/model/provider errors where the thrown object carries valuable
+structured diagnostics (`cause`, `statusCode`, `responseBody`, `url`, etc.). Historically, only
+`error.message` survived, which blocked root-cause diagnosis and structured programmatic handling.
+
+Issue reference: <https://github.com/jlevy/markform/issues/142>
+
+## Design
+
+### Approach
+
+Use additive, backward-compatible API extensions:
+
+- `FillStatus` includes optional `error?: Error` when `reason === 'error'`.
+- `FillCallbacks` includes optional `onError(error, { turnNumber })` invoked before returning the
+  error result from the fill loop.
+- Existing `message` and `statusDetail` behavior remains intact for compatibility.
+
+### Components
+
+- `packages/markform/src/harness/harnessTypes.ts`
+  - `FillStatus` contract
+  - `FillCallbacks` contract
+- `packages/markform/src/harness/programmaticFill.ts`
+  - serial and parallel catch paths
+  - parse/model-resolution failure paths
+- `packages/markform/tests/unit/harness/programmaticFill.test.ts`
+  - status error preservation + callback semantics
+- `packages/markform/docs/markform-apis.md`
+  - public API docs for `FillStatus` and callback list
+
+### API Changes
+
+- Add `error?: Error` to `FillStatus` error variant.
+- Add `onError?(error: Error, context: { turnNumber: number }): void` to `FillCallbacks`.
+
+These are optional additions and remain backward-compatible for existing consumers.
+
+## Implementation Plan
+
+### Phase 1: Validate and Land Issue #142 Contract
+
+- [x] Confirm all relevant failure paths preserve `Error` where available.
+- [x] Confirm `onError` firing semantics in serial and parallel loops.
+- [x] Add/adjust tests for any uncovered behavior regressions.
+- [x] Update API docs to include `FillStatus.error` and `onError` callback.
+- [x] Run targeted quality gates and finalize bead/issue status updates.
+
+## Testing Strategy
+
+- Unit tests for:
+  - serial agent throw -> `status.error` preserved, `onError` called once with turn context
+  - parallel item throw -> status + callback semantics preserved
+  - pre-fill parse/model resolution throws -> `status.error` preserved
+- Regression tests ensure non-Error thrown values remain handled safely.
+
+## Rollout Plan
+
+- No migration required (additive API changes).
+- Release notes should mention enhanced error diagnostics for `fillForm()` consumers.
+
+## Open Questions
+
+- Should `onError` also fire for pre-fill setup failures (parse/model/input context), or remain
+  fill-loop-only?
+- Should a future schema-safe `errorSummary` object be added to `FillRecord` for offline analysis?
+
+## References
+
+- GitHub issue: <https://github.com/jlevy/markform/issues/142>

--- a/packages/markform/src/harness/harnessTypes.ts
+++ b/packages/markform/src/harness/harnessTypes.ts
@@ -311,6 +311,9 @@ export interface FillCallbacks {
   /** Called when a turn completes */
   onTurnComplete?(progress: TurnProgress): void;
 
+  /** Called when a fill turn fails due to an agent or provider error */
+  onError?(error: Error, context: { turnNumber: number }): void;
+
   /** Called before a tool executes */
   onToolStart?(call: {
     name: string;
@@ -548,11 +551,12 @@ export interface TurnProgress {
  * - `max_turns` - Hit overall maxTurnsTotal safety limit
  * - `batch_limit` - Hit maxTurnsThisCall per-call limit (resume by calling again)
  * - `cancelled` - Aborted via signal
- * - `error` - Unexpected error
+ * - `error` - Unexpected error (`error` carries the original Error when available)
  */
 export type FillStatus =
   | { ok: true }
-  | { ok: false; reason: 'max_turns' | 'batch_limit' | 'cancelled' | 'error'; message?: string };
+  | { ok: false; reason: 'max_turns' | 'batch_limit' | 'cancelled'; message?: string }
+  | { ok: false; reason: 'error'; message?: string; error?: Error };
 
 /**
  * Result of the fillForm operation.


### PR DESCRIPTION
## Summary
This change fixes issue #142 by preserving structured `Error` objects in `fillForm()` failure results and by adding an `onError` callback for real-time error reporting. It makes serial and parallel execution paths consistent when agent/provider calls fail, while keeping the API backward compatible.

## Changes
- Added `FillCallbacks.onError(error, { turnNumber })` to the public harness callback contract.
- Extended `FillStatus` so `reason: 'error'` can include `error?: Error`.
- Updated `programmaticFill` serial catch paths to preserve and return error objects and trigger `onError`.
- Updated parallel execution error handling so aborted batch items surface as top-level error status (instead of degrading into unrelated terminal statuses).
- Added unit coverage for serial and parallel `onError` behavior and error-object preservation (including model-resolution errors).
- Added implementation spec doc: `docs/project/specs/active/plan-2026-02-14-fill-error-diagnostics.md`.
- Synced tbd docs cache metadata updates in `.tbd/config.yml`.

## Test Plan
- [x] Unit tests pass (`pnpm --filter markform test -- --run packages/markform/tests/unit/harness/programmaticFill.test.ts`)
- [x] Build succeeds (`pnpm build` via `pnpm precommit`)
- [x] Full quality gates pass (`pnpm precommit`)
- [ ] Manual testing steps
  - Run `markform fill` on a form with a mocked failing provider and verify `status.reason === 'error'` and `status.error` is present.
  - Run `fillForm({ enableParallel: true })` with one failing parallel item and verify top-level error status is returned immediately.
  - Verify callback behavior by attaching `callbacks.onError` and checking turn numbers in logs.
- [x] Edge cases considered
  - Non-`Error` thrown values are still handled safely via string fallback messages.
  - Pre-fill failures (parse/model resolution/input coercion) preserve error data where available.
  - Callback exceptions are still swallowed to avoid aborting fills.

## Related Beads
- `mf-d924` (epic)
- `mf-7sfz`
- `mf-93vh`
- `mf-cq1f`
- `mf-r1hs`
