### PR TITLE
fix(ci): stop coverage badges from pushing to protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           # Only show changed files on PRs, show all on main
           file-coverage-mode: ${{ github.event_name == 'pull_request' && 'changes' || 'all' }}
 
-      # Generate and commit coverage badges (main branch only)
+      # Generate coverage badges (main branch only, no auto-commit since branch protection blocks direct pushes)
       - name: Coverage Badges
         uses: jpb06/coverage-badges-action@v1.4.6
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -50,19 +50,4 @@ jobs:
           coverage-summary-path: packages/markform/coverage/coverage-summary.json
           output-folder: ./badges
           branches: main
-
-      - name: Update badge links to this run
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        env:
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        run: |
-          # Update badge links using the standalone script
-          ./scripts/update-badge-links.sh
-          # Commit the README change
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git diff --staged --quiet || git commit -m "chore: update badge links to run #${{ github.run_number }}"
-          git push
+          no-commit: true


### PR DESCRIPTION
## Summary
- The coverage badges action (`jpb06/coverage-badges-action`) and badge link update step were trying to `git push` directly to `main`, which fails because branch protection rules require all changes go through pull requests
- Set `no-commit: true` on the badges action so it generates badges without committing/pushing
- Removed the badge link update step that also attempted to push to `main`

## Test plan
- [ ] CI passes on this PR (the actual fix is for the post-test steps on `main` pushes, but this PR should at least pass all test/lint/build steps)
- [ ] After merge, the next `main` push should no longer fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)