### PR TITLE
fix(ci): update README diagram and fix tryscript badge test

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ flowchart LR
         subgraph ENGINE["<b>CORE TYPESCRIPT APIS</b><br/>Markdoc parser, serializer,<br/>patch application,<br/>validation (jiti for rules)"]
         end
 
-        subgraph TEST["<b>TESTING FRAMEWORK</b><br/>Golden session testing<br/>(.session.yaml transcripts)"]
+        subgraph PARSER["<b>PARSER</b><br/>Markform language<br/>parser/serializer"]
         end
 
         CLI --> ENGINE
@@ -462,7 +462,7 @@ flowchart LR
         AGENT --> HARNESS
         AGENT --> ENGINE
         HARNESS --> ENGINE
-        ENGINE --> TEST
+        ENGINE --> PARSER
     end
 
     SPEC ~~~ IMPL
@@ -477,7 +477,7 @@ flowchart LR
     style CLI fill:#ffe8cc,stroke:#fb8500
     style AGENT fill:#ffe8cc,stroke:#fb8500
     style HARNESS fill:#ffe8cc,stroke:#fb8500
-    style TEST fill:#ffe8cc,stroke:#fb8500
+    style PARSER fill:#ffe8cc,stroke:#fb8500
 ```
 
 ## CLI Commands

--- a/packages/markform/tests/cli/commands.tryscript.md
+++ b/packages/markform/tests/cli/commands.tryscript.md
@@ -6,12 +6,11 @@ env:
   CLI: ./dist/bin.mjs
 timeout: 30000
 ---
-
 # Markform CLI Command Tests
 
 This file tests all Markform CLI commands for correct output and exit codes.
 
----
+* * *
 
 ## Global Options
 
@@ -94,7 +93,7 @@ Getting Started:
 ? 0
 ```
 
----
+* * *
 
 ## Inspection Commands
 
@@ -194,7 +193,7 @@ optional_year: (unanswered)
 ? 0
 ```
 
----
+* * *
 
 ## Documentation Commands
 
@@ -204,7 +203,7 @@ optional_year: (unanswered)
 $ $CLI readme | head -5
 # Markform
 
-[![CI](https://github.com/jlevy/markform/actions/workflows/ci.yml/badge.svg)][..]
+[![Follow @ojoshe on X][..]][..]
 ...
 ? 0
 ```
@@ -226,7 +225,7 @@ Forms render cleanly on GitHub since structure is hidden in comments.
 ? 0
 ```
 
----
+* * *
 
 ## Export Commands
 
@@ -269,7 +268,7 @@ $ $CLI schema examples/simple/simple.form.md | head -10
 ? 0
 ```
 
----
+* * *
 
 ## Utility Commands
 
@@ -293,7 +292,7 @@ anthropic/
 ? 0
 ```
 
----
+* * *
 
 ## Report Command
 
@@ -329,7 +328,7 @@ Generate filtered markdown report (excludes instructions, report=false elements)
 ? 0
 ```
 
----
+* * *
 
 ## Render Command
 
@@ -352,7 +351,7 @@ $ $CLI render examples/simple/simple.form.md --dry-run
 ? 0
 ```
 
----
+* * *
 
 ## Spec Command
 
@@ -373,7 +372,7 @@ humans.
 ? 0
 ```
 
----
+* * *
 
 ## APIs Command
 
@@ -388,7 +387,7 @@ programmatically.
 ? 0
 ```
 
----
+* * *
 
 ## Validate Command --syntax Option
 


### PR DESCRIPTION
## Summary
- Rename TEST subgraph to PARSER in README architecture diagram
- Fix commands.tryscript.md badge expectation to match current README badge order (was causing CI failure on main after badge changes in #150)

## Test plan
- [x] All 2206 unit tests pass
- [x] All 24 tryscript CLI tests pass (including the previously failing commands.tryscript.md)
- [ ] CI passes on this PR