### PR TITLE
chore: release markform v0.1.25

### DIFF
--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,22 +1,32 @@
 # markform
 
+## 0.1.25
+
+### Patch Changes
+
+- Per-column table constraints, FillRecord performance metrics, onError callback, serve
+  UI improvements, parse/serialize fixes
+
 ## 0.1.24
 
 ### Patch Changes
 
-- a048f20: CLI form-filling commands (set, next, patch), append/delete patch ops, Claude Code skill integration, fill record improvements, and test coverage enhancements
+- a048f20: CLI form-filling commands (set, next, patch), append/delete patch ops, Claude
+  Code skill integration, fill record improvements, and test coverage enhancements
 
 ## 0.1.23
 
 ### Patch Changes
 
-- 5ed47e2: Extensible provider support via ProviderAdapter; fix skip reason display in badge pill
+- 5ed47e2: Extensible provider support via ProviderAdapter; fix skip reason display in
+  badge pill
 
 ## 0.1.22
 
 ### Patch Changes
 
-- a8738d4: Render subpath export, skip reason display, URL parsing fix, API error improvements
+- a8738d4: Render subpath export, skip reason display, URL parsing fix, API error
+  improvements
 
 ## 0.1.21
 
@@ -34,13 +44,15 @@
 
 ### Patch Changes
 
-- 114105b: FillRecord implementation, security fixes, proxy support, and URL rendering improvements
+- 114105b: FillRecord implementation, security fixes, proxy support, and URL rendering
+  improvements
 
 ## 0.1.18
 
 ### Patch Changes
 
-- 28696dc: Add parallel form filling with plan command, ParallelHarness, and order/parallel attributes
+- 28696dc: Add parallel form filling with plan command, ParallelHarness, and
+  order/parallel attributes
 
 ## 0.1.17
 
@@ -52,7 +64,9 @@
 
 ### Patch Changes
 
-- 97390e0: Add HTML comment syntax as a cleaner alternative to Markdoc tags, making forms render as valid Markdown on GitHub while maintaining full backward compatibility with existing tag syntax
+- 97390e0: Add HTML comment syntax as a cleaner alternative to Markdoc tags, making
+  forms render as valid Markdown on GitHub while maintaining full backward compatibility
+  with existing tag syntax
 
 ## 0.1.15
 
@@ -64,49 +78,59 @@
 
 ### Patch Changes
 
-- 8992edc: Add array-to-checkboxes coercion for LLM compatibility, complete checkbox mode states in prompts, and enhance documentation
+- 8992edc: Add array-to-checkboxes coercion for LLM compatibility, complete checkbox
+  mode states in prompts, and enhance documentation
 
 ## 0.1.13
 
 ### Patch Changes
 
-- 08634fd: Add best-effort patch application with value coercion, coercion warnings in session files, and increase maxStepsPerTurn default to 20
+- 08634fd: Add best-effort patch application with value coercion, coercion warnings in
+  session files, and increase maxStepsPerTurn default to 20
 
 ## 0.1.12
 
 ### Patch Changes
 
-- 2a70552: Add resumable form fills, standardize patch property names, rename maxTurns to maxTurnsTotal
+- 2a70552: Add resumable form fills, standardize patch property names, rename maxTurns
+  to maxTurnsTotal
 
 ## 0.1.11
 
 ### Patch Changes
 
-- 8d72787: Support boolean checkbox values, standardize patch property names, and improve error messages
+- 8d72787: Support boolean checkbox values, standardize patch property names, and
+  improve error messages
 
 ## 0.1.10
 
 ### Patch Changes
 
-- 576e19b: Add structured error handling with typed error hierarchy, improve frontmatter parsing using Markdoc native support, add defensive null checks for table rows and patch validation, and significantly improve test coverage to 60%
+- 576e19b: Add structured error handling with typed error hierarchy, improve frontmatter
+  parsing using Markdoc native support, add defensive null checks for table rows and
+  patch validation, and significantly improve test coverage to 60%
 
 ## 0.1.9
 
 ### Patch Changes
 
-- a9079b4: Improve serve command with syntax highlighting and tabs, add inline field instructions to prompts, rename generatePatches to fill_form, add wire format to session logs, fix table/date/year support in CLI, fix multi_select infinite loop
+- a9079b4: Improve serve command with syntax highlighting and tabs, add inline field
+  instructions to prompts, rename generatePatches to fill_form, add wire format to
+  session logs, fix table/date/year support in CLI, fix multi_select infinite loop
 
 ## 0.1.8
 
 ### Patch Changes
 
-- b803791: Fix serialization of table values and frontmatter, improve rejection feedback handling in LLM prompts, and add comprehensive golden test coverage
+- b803791: Fix serialization of table values and frontmatter, improve rejection feedback
+  handling in LLM prompts, and add comprehensive golden test coverage
 
 ## 0.1.7
 
 ### Patch Changes
 
-- 71692eb: Unified fill logging, CLI improvements, JSON Schema enhancements, Zod v4 upgrade
+- 71692eb: Unified fill logging, CLI improvements, JSON Schema enhancements, Zod v4
+  upgrade
 
 ## 0.1.6
 
@@ -124,13 +148,15 @@
 
 ### Patch Changes
 
-- 5b1794b: Add custom tool injection, unified field tag syntax, table-field type, date/year field support, and various bug fixes
+- 5b1794b: Add custom tool injection, unified field tag syntax, table-field type,
+  date/year field support, and various bug fixes
 
 ## 0.1.3
 
 ### Patch Changes
 
-- 3ea571b: - fix: Move ai from peerDependencies to regular dependencies (resolves install issues for new users)
+- 3ea571b: - fix: Move ai from peerDependencies to regular dependencies (resolves
+  install issues for new users)
   - refactor: Change multi-format export from raw to report format
   - docs: Update README example and add MPAA rating to minimal form
   - fix(examples): simplify movie-research-minimal form structure
@@ -139,16 +165,25 @@
 
 ### Patch Changes
 
-- 1ad64ba: Major internal refactoring and new features including: unified response model with notes and skip/abort reasons (%SKIP%/%ABORT% syntax), date-field and year-field types, research API and CLI command, smart fence serialization, forms directory for centralized output, report command with multi-format export, web search support for Anthropic/xAI, token counting in logs, interactive file viewer after fill, Prettier/ESLint integration, modularized parser, and comprehensive movie research examples
+- 1ad64ba: Major internal refactoring and new features including: unified response model
+  with notes and skip/abort reasons (%SKIP%/%ABORT% syntax), date-field and year-field
+  types, research API and CLI command, smart fence serialization, forms directory for
+  centralized output, report command with multi-format export, web search support for
+  Anthropic/xAI, token counting in logs, interactive file viewer after fill,
+  Prettier/ESLint integration, modularized parser, and comprehensive movie research
+  examples
 
 ## 0.1.1
 
 ### Patch Changes
 
-- Add skip_field operation for optional field skipping, URL field types (url-field, url-list), web search tool support, role-aware form completion, improved prompts and verbose logging
+- Add skip_field operation for optional field skipping, URL field types (url-field,
+  url-list), web search tool support, role-aware form completion, improved prompts and
+  verbose logging
 
 ## 0.1.0
 
 ### Minor Changes
 
-- 2127c78: Add programmatic fill API, doc block syntax, examples command, and publishing automation
+- 2127c78: Add programmatic fill API, doc block syntax, examples command, and publishing
+  automation

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,33 +1,36 @@
-## What's Changed
+## What’s Changed
 
 ### Features
 
-- **Frontmatter validation**: Added MarkformSectionInputSchema with Zod validation for more reliable frontmatter parsing
-- **Timing metrics**: Added startMs to timeline entries and tool calls for relative timing analysis in FillRecords
+- **Per-column constraints for table fields**: Table columns now support type-specific
+  constraints (`minLength`, `maxLength`, `pattern`, `enum` for strings; `min`, `max`,
+  `integer` for numbers; `min`/`max` for dates and years).
+  Specified via `columnTypes` attributes, enforced during validation, preserved through
+  round-trips, and mapped to JSON Schema.
+- **FillRecord performance metrics**: FillRecord now includes `llmParallelism`,
+  `llmTimeMs`/`totalMs` timing breakdown, and `avgDurationMs` per tool.
+  Text summaries show s/turn and s/field rates.
+  HTML dashboard gains a parallelism card and duration rates.
+- **`onError` callback and error preservation**: New `onError` callback in
+  `FillCallbacks` for real-time error reporting with turn context.
+  `FillStatus` now preserves the full Error object (cause chain, statusCode, etc.)
+  as a discriminated union.
+- **Agent-friendly `examples --list`**: `markform examples --list` now supports
+  `--format=json`. Examples reordered by complexity with twitter-thread registered.
 
 ### Fixes
 
-- **Reliable tool calling**: Default toolChoice to 'required' for consistent agent behavior
-- **Parallel execution tracking**: Fixed executionId passing and per-execution turn tracking for correct tool call matching
-- **Frontmatter round-trips**: Preserve title/description fields when serializing forms
-- **Concurrency handling**: Corrected parallel execution concurrency and FillRecord tracking
-
-### Refactoring
-
-- **YAML formatting**: Centralized stringify options and improved output readability
-- **HTML comment syntax**: Migrated all forms to HTML comment syntax for field attributes
-- **Config handling**: Centralized harness config snake_case/camelCase mapping
-- **Execution IDs**: Self-documenting format with eid: prefix
-
-### Testing
-
-- Comprehensive frontmatter unit tests
-- Parallel execution integration and tracking tests
-- Updated test expectations for HTML comment syntax
+- **Serve UI**: Tabs reorganized (Form, Report, Source, ...) with hash-based routing for
+  direct linking
+- **`set` command**: Now surfaces validation warnings for patched fields
+- **Parse/serialize**: Fixed instruction line-break loss during round-trip; explicit
+  checkboxes render as Yes/No in reports
+- **CLI logging**: All diagnostic log functions now write to stderr for pipeline
+  compatibility
 
 ### Documentation
 
-- Clarified .env file loading behavior
-- Updated manual test docs and gitignore patterns
+- Per-column constraints documented in spec and reference
+- QA and manual tests consolidated into `tests/qa/`
 
-**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.20...v0.1.21
+**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.24...v0.1.25


### PR DESCRIPTION
## What’s Changed

### Features

- **Per-column constraints for table fields**: Table columns now support type-specific
  constraints (`minLength`, `maxLength`, `pattern`, `enum` for strings; `min`, `max`,
  `integer` for numbers; `min`/`max` for dates and years).
  Specified via `columnTypes` attributes, enforced during validation, preserved through
  round-trips, and mapped to JSON Schema.
- **FillRecord performance metrics**: FillRecord now includes `llmParallelism`,
  `llmTimeMs`/`totalMs` timing breakdown, and `avgDurationMs` per tool.
  Text summaries show s/turn and s/field rates.
  HTML dashboard gains a parallelism card and duration rates.
- **`onError` callback and error preservation**: New `onError` callback in
  `FillCallbacks` for real-time error reporting with turn context.
  `FillStatus` now preserves the full Error object (cause chain, statusCode, etc.)
  as a discriminated union.
- **Agent-friendly `examples --list`**: `markform examples --list` now supports
  `--format=json`. Examples reordered by complexity with twitter-thread registered.

### Fixes

- **Serve UI**: Tabs reorganized (Form, Report, Source, ...) with hash-based routing for
  direct linking
- **`set` command**: Now surfaces validation warnings for patched fields
- **Parse/serialize**: Fixed instruction line-break loss during round-trip; explicit
  checkboxes render as Yes/No in reports
- **CLI logging**: All diagnostic log functions now write to stderr for pipeline
  compatibility

### Documentation

- Per-column constraints documented in spec and reference
- QA and manual tests consolidated into `tests/qa/`

**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.24...v0.1.25
