### PR TITLE
chore: release markform v0.1.26

### DIFF
--- a/.changeset/v0.1.26.md
+++ b/.changeset/v0.1.26.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Fix tool error handling and parallel fill path

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.26
+
+### Patch Changes
+
+- b95f40a: Fix tool error handling and parallel fill path
+
 ## 0.1.25
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## What's Changed

### Fixes

- **Tool error handling**: Fixed `wrapTool()` to re-throw errors with guaranteed non-empty messages instead of swallowing them, preserving AI SDK's proper `is_error` semantics and telemetry (#153)
- **Parallel fill path**: `fillFormParallel` now correctly receives and passes `providerTools` to sub-agents, matching the serial path behavior (#154)

### Documentation

- Updated plan spec to reflect revised error handling approach

**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.25...v0.1.26
