### PR TITLE
chore: release markform v0.1.27

### DIFF
--- a/.changeset/v0.1.27.md
+++ b/.changeset/v0.1.27.md
@@ -1,5 +1,0 @@
----
-"markform": patch
----
-
-Fill harness observability and signal propagation

--- a/packages/markform/CHANGELOG.md
+++ b/packages/markform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # markform
 
+## 0.1.27
+
+### Patch Changes
+
+- c7b0278: Fill harness observability and signal propagation
+
 ## 0.1.26
 
 ### Patch Changes

--- a/packages/markform/package.json
+++ b/packages/markform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markform",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Markdown forms for token-friendly workflows",
   "license": "AGPL-3.0-or-later",
   "author": "Joshua Levy",


### PR DESCRIPTION
## What's Changed

### Features

- **Fill harness observability**: Complete observability and signal propagation for the fill harness (MF-1 through MF-5), including event callbacks, raw event logging, and structured observability hooks

### Fixes

- Fixed `onLlmCallEnd` not firing on `generateText()` failure — now reports error and duration
- Fixed italic formatting on report sentinel values (empty/skipped/aborted)
- Fixed JSON serialization of eventLog tool input/output

### Documentation

- Added observability documentation for fill harness covering MF-1 through MF-5

**Full commit history**: https://github.com/jlevy/markform/compare/v0.1.26...v0.1.27
